### PR TITLE
Modal 컴포넌트 구현

### DIFF
--- a/frontend/src/components/modal/index.ts
+++ b/frontend/src/components/modal/index.ts
@@ -1,0 +1,17 @@
+class Modal {
+  constructor() {
+    addEventListener('click', this.closeModal.bind(this));
+  }
+
+  closeModal(e): void {
+    const { target } = e;
+    const modalElement: HTMLElement | null = document.querySelector('.modal');
+    const modalCloseButton: HTMLElement | null = document.querySelector('.modal-close-button');
+
+    if (modalElement && (target === modalElement || target === modalCloseButton)) {
+      modalElement.style.display = 'none';
+    }
+  }
+}
+
+export default new Modal();

--- a/frontend/src/components/modal/index.ts
+++ b/frontend/src/components/modal/index.ts
@@ -19,6 +19,12 @@ import './style.scss';
       addEventListener('click', this.closeModal.bind(this));
     }
 
+    attributeChangedCallback(attrName, oldVal, newVal) {
+      if (oldVal !== newVal) {
+        this[attrName] = newVal;
+      }
+    }
+
     closeModal(e): void {
       const { target } = e;
       const modalElement: HTMLElement | null = document.querySelector('.modal');

--- a/frontend/src/components/modal/index.ts
+++ b/frontend/src/components/modal/index.ts
@@ -1,17 +1,44 @@
-class Modal {
-  constructor() {
-    addEventListener('click', this.closeModal.bind(this));
-  }
+import { modalContents } from './modalContents';
+import './style.scss';
+(() => {
+  const Modal = class extends HTMLElement {
+    public type: string;
 
-  closeModal(e): void {
-    const { target } = e;
-    const modalElement: HTMLElement | null = document.querySelector('.modal');
-    const modalCloseButton: HTMLElement | null = document.querySelector('.modal-close-button');
-
-    if (modalElement && (target === modalElement || target === modalCloseButton)) {
-      modalElement.style.display = 'none';
+    constructor() {
+      super();
+      this.type = 'source';
+      this.title = '소스 불러오기';
     }
-  }
-}
 
-export default new Modal();
+    static get observedAttributes() {
+      return ['type', 'title'];
+    }
+
+    connectedCallback() {
+      this.render();
+      addEventListener('click', this.closeModal.bind(this));
+    }
+
+    closeModal(e): void {
+      const { target } = e;
+      const modalElement: HTMLElement | null = document.querySelector('.modal');
+      const modalCloseButton: HTMLElement | null = document.querySelector('.modal-close-button');
+
+      if (modalElement && (target === modalElement || target === modalCloseButton)) {
+        modalElement.style.display = 'none';
+      }
+    }
+
+    render() {
+      this.innerHTML = `
+        <div id='modal' class='modal'>
+          <div class='modal-content'>
+              <h2>${this.title}</h2>
+              ${modalContents[this.type]}
+              <modal-buttons type=${this.type}></modal-buttons>
+          </div>
+        </div>`;
+    }
+  };
+  customElements.define('editor-modal', Modal);
+})();

--- a/frontend/src/components/modal/modal-buttons/index.ts
+++ b/frontend/src/components/modal/modal-buttons/index.ts
@@ -1,0 +1,35 @@
+import { modalButtons } from './modalButtons';
+
+(() => {
+  const ModalButtons = class extends HTMLElement {
+    private type: string;
+
+    constructor() {
+      super();
+      this.type = 'source';
+    }
+
+    static get observedAttributes() {
+      return ['type'];
+    }
+
+    connectedCallback() {
+      this.render();
+
+      const closeButtonElement: HTMLElement | null = document.querySelector('.modal-close-button');
+
+      if (this.type === 'effect' && closeButtonElement) {
+        closeButtonElement.style.marginLeft = '0rem';
+      }
+    }
+
+    render() {
+      this.innerHTML = `
+        <section class='source-upload-buttons'>
+            ${modalButtons[this.type]}
+        </section>
+        `;
+    }
+  };
+  customElements.define('modal-buttons', ModalButtons);
+})();

--- a/frontend/src/components/modal/modal-buttons/modalButtons.ts
+++ b/frontend/src/components/modal/modal-buttons/modalButtons.ts
@@ -1,0 +1,6 @@
+export const modalButtons = {
+  source: `
+    <button class='modal-green-button' type='button'>불러오기</button>
+    <button class='modal-close-button' type='button'>취소</button>`,
+  effect: `<button class='modal-close-button' type='button'>취소</button>`
+};

--- a/frontend/src/components/modal/modalContents.ts
+++ b/frontend/src/components/modal/modalContents.ts
@@ -1,0 +1,3 @@
+export const modalContents: object = {
+  source: '<source-upload-form class=modal-component></source-upload-form>'
+};

--- a/frontend/src/components/modal/style.scss
+++ b/frontend/src/components/modal/style.scss
@@ -2,6 +2,21 @@ $baseColor: #212121;
 $borderColor: #e0e0e0;
 $greenColor: #03c75a;
 
+%modal-buttons {
+  width: 90%;
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+%modal-button {
+  width: 25%;
+  height: 2rem;
+  border: 1px solid $borderColor;
+  border-radius: 3px;
+  color: #ffffff;
+}
+
 .modal {
   display: flex;
   justify-content: center;
@@ -28,4 +43,20 @@ $greenColor: #03c75a;
   border: 2px solid $borderColor;
   border-radius: 5px;
   color: #ffffff;
+}
+
+.source-upload-buttons {
+  @extend %modal-buttons;
+
+  .modal-green-button {
+    @extend %modal-button;
+    background-color: $greenColor;
+    margin-right: 0.5rem;
+  }
+
+  .modal-close-button {
+    @extend %modal-button;
+    background-color: $baseColor;
+    margin-left: 0.5rem;
+  }
 }

--- a/frontend/src/components/modal/style.scss
+++ b/frontend/src/components/modal/style.scss
@@ -38,7 +38,6 @@ $greenColor: #03c75a;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  border: 1px solid #000000;
   background-color: $baseColor;
   border: 2px solid $borderColor;
   border-radius: 5px;

--- a/frontend/src/components/modal/style.scss
+++ b/frontend/src/components/modal/style.scss
@@ -3,18 +3,20 @@ $borderColor: #e0e0e0;
 $greenColor: #03c75a;
 
 %modal-buttons {
-  width: 90%;
   display: flex;
   justify-content: center;
   margin-top: 1rem;
+
+  width: 90%;
 }
 
 %modal-button {
   width: 25%;
   height: 2rem;
+
+  color: #ffffff;
   border: 1px solid $borderColor;
   border-radius: 3px;
-  color: #ffffff;
 }
 
 .modal {
@@ -32,16 +34,19 @@ $greenColor: #03c75a;
 }
 
 .modal-content {
-  width: 50%;
-  height: 60%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  text-align: center;
+
+  width: 50%;
+  height: 60%;
+
+  color: #ffffff;
   background-color: $baseColor;
   border: 2px solid $borderColor;
   border-radius: 5px;
-  color: #ffffff;
+
+  text-align: center;
 }
 
 .source-upload-buttons {
@@ -49,13 +54,13 @@ $greenColor: #03c75a;
 
   .modal-green-button {
     @extend %modal-button;
-    background-color: $greenColor;
     margin-right: 0.5rem;
+    background-color: $greenColor;
   }
 
   .modal-close-button {
     @extend %modal-button;
-    background-color: $baseColor;
     margin-left: 0.5rem;
+    background-color: $baseColor;
   }
 }

--- a/frontend/src/components/modal/style.scss
+++ b/frontend/src/components/modal/style.scss
@@ -49,6 +49,13 @@ $greenColor: #03c75a;
   text-align: center;
 }
 
+.modal-component {
+  width: 100%;
+}
+modal-buttons {
+  width: 100%;
+}
+
 .source-upload-buttons {
   @extend %modal-buttons;
 

--- a/frontend/src/components/modal/style.scss
+++ b/frontend/src/components/modal/style.scss
@@ -19,6 +19,9 @@ $greenColor: #03c75a;
 .modal-content {
   width: 50%;
   height: 60%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
   border: 1px solid #000000;
   background-color: $baseColor;

--- a/frontend/src/components/modal/style.scss
+++ b/frontend/src/components/modal/style.scss
@@ -1,0 +1,28 @@
+$baseColor: #212121;
+$borderColor: #e0e0e0;
+$greenColor: #03c75a;
+
+.modal {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.modal-content {
+  width: 50%;
+  height: 60%;
+  text-align: center;
+  border: 1px solid #000000;
+  background-color: $baseColor;
+  border: 2px solid $borderColor;
+  border-radius: 5px;
+  color: #ffffff;
+}


### PR DESCRIPTION
## 📕 제목

Modal 컴포넌트 구현
관련이슈 #37

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 배경색은 진한 회색으로 한다. 
- [x] 배경을 눌렀을때 모달창이 닫히도록 구현합니다.
- [x] 취소 버튼이 존재하면 취소 버튼을 눌러도 모달창이 닫히도록 구현합니다.

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Modal 컴포넌트를 사용하고싶을때
  - <strong>``<editor-modal type='source' title='소스 불러오기'></editor-modal>``</strong> 형식으로 불러옵니다.
![image](https://user-images.githubusercontent.com/55783203/100178390-1c457780-2f17-11eb-80ee-9f5715b9d78d.png)

- editor-modal 컴포넌트 내부 모습
![image](https://user-images.githubusercontent.com/55783203/100178447-37b08280-2f17-11eb-9074-26f4ceda9e45.png)

- modal/modalContents.js에 modal content로 사용할 컴포넌트를 지정해줍니다.
![image](https://user-images.githubusercontent.com/55783203/100178605-878f4980-2f17-11eb-83a8-b4c5f9cae19b.png)
  - modal에서 받은 type을 키로 설정해준다.
  - 키값은 modal 안에 넣을 컴포넌트를 넣어줍니다.
  - <strong>반드시 class=modal-component을 넣어줘야합니다!</strong> (그렇지 않으면 width 설정이 제대로 안먹히더라구요...)

- modal-buttons 컴포넌트
![image](https://user-images.githubusercontent.com/55783203/100178740-e81e8680-2f17-11eb-98ee-9d3c4ad932cc.png)

- modalButtons에 아래와 같이 UI prototype에 맞게 작성해주시면 됩니다! (파일 저장 부분은 source와 동일하고 저장하기로 문자열만 바꿔주면 됩니다! effect는 UI Prototype에서 확인 버튼이 없어 취소 버튼 하나만 나오도록 했습니다.)
![image](https://user-images.githubusercontent.com/55783203/100178785-fff60a80-2f17-11eb-8766-1a634ee31331.png)
  - 하드코딩으로 이루어져있으며 아토믹하게 만들 수도 있을 것 같아 추후에 리팩토링 작업을 할 것 같습니다😉