### PR TITLE
EffectList 컴포넌트 제작 및 루트 컴포넌트에서 모든 이벤트 처리 구현

### DIFF
--- a/frontend/src/common/types/eventDataType.ts
+++ b/frontend/src/common/types/eventDataType.ts
@@ -1,0 +1,12 @@
+import {EventType} from './eventType';
+
+interface EventDataType{
+    eventTypes: EventType[],
+    eventKey: string,
+    listeners: EventListener[],
+    bindObj: Object
+}
+
+export {
+    EventDataType
+}

--- a/frontend/src/common/types/eventDataType.ts
+++ b/frontend/src/common/types/eventDataType.ts
@@ -1,10 +1,10 @@
 import {EventType} from './eventType';
 
 interface EventDataType{
-    eventTypes: EventType[],
-    eventKey: string,
-    listeners: EventListener[],
-    bindObj: Object
+    eventTypes: EventType[];
+    eventKey: string;
+    listeners: EventListener[];
+    bindObj: Object;
 }
 
 export {

--- a/frontend/src/common/types/eventTargetDataType.ts
+++ b/frontend/src/common/types/eventTargetDataType.ts
@@ -1,0 +1,8 @@
+interface EventTargetDataType{
+    listener: EventListener;
+    bindObj: Object;
+}
+
+export {
+    EventTargetDataType
+}

--- a/frontend/src/common/types/eventType.ts
+++ b/frontend/src/common/types/eventType.ts
@@ -1,0 +1,10 @@
+enum EventType{
+    click = 'click',
+    mouseover = 'mouseover'
+}
+const eventTypes = ['click', 'mouseover'];
+
+export{
+    EventType,
+    eventTypes
+}

--- a/frontend/src/common/types/index.js
+++ b/frontend/src/common/types/index.js
@@ -1,0 +1,3 @@
+export { EventType, eventTypes } from './eventType';
+export { EventDataType } from './eventDataType';
+export { EventTargetDataType } from './eventTargetDataType';

--- a/frontend/src/common/util/EventUtil.ts
+++ b/frontend/src/common/util/EventUtil.ts
@@ -1,0 +1,12 @@
+import { EventDataType } from '@types';
+
+interface RootElementType extends HTMLElement{
+    registerEventListener: (eventData:EventDataType)=>{};
+}
+
+const rootElement: RootElementType | null = document.querySelector('#root');
+const registerEventToRoot = (eventData: EventDataType) => rootElement?.registerEventListener(eventData);
+
+export {
+    registerEventToRoot
+}

--- a/frontend/src/common/util/index.js
+++ b/frontend/src/common/util/index.js
@@ -1,0 +1,1 @@
+export { registerEventToRoot } from "./EventUtil";

--- a/frontend/src/components/App/App.ts
+++ b/frontend/src/components/App/App.ts
@@ -41,10 +41,10 @@ import { EventDataType, eventTypes, EventTargetDataType } from "@types";
       );
     }
 
-    eventListenerForRegistrant(e) {
+    eventListenerForRegistrant(e): void {
       const { target } = e;
       
-      if (!this.isEventTarget(target) || !this.eventListenerCollectors) return;
+      if (!target || !this.isEventTarget(target) || !this.eventListenerCollectors) return;
       
       const eventType = e.type;
       const eventKey = target.getAttribute('event-key');
@@ -57,7 +57,7 @@ import { EventDataType, eventTypes, EventTargetDataType } from "@types";
       return (eventKey)? true : false;
     }
 
-    excuteEventListenerForTarget(eventType: string, eventKey: string, e:Event){
+    excuteEventListenerForTarget(eventType: string, eventKey: string, e:Event): void{
       if(!this.eventListenerCollectors) return;
 
       const eventListenerCollector = this.eventListenerCollectors.get(eventType);
@@ -67,7 +67,7 @@ import { EventDataType, eventTypes, EventTargetDataType } from "@types";
       }
     }
 
-    registerEventListener(eventData: EventDataType){
+    registerEventListener(eventData: EventDataType): void{
       const { eventTypes, eventKey, listeners, bindObj } = eventData;
 
       eventTypes.forEach((eventType, idx)=>{

--- a/frontend/src/components/App/App.ts
+++ b/frontend/src/components/App/App.ts
@@ -1,25 +1,87 @@
-import './App.scss';
+import "./App.scss";
+import { EventDataType, eventTypes, EventTargetDataType } from "@types";
+
 
 (() => {
   const App = class extends HTMLElement {
+    private eventListenerCollectors: Map<string, Map<string, EventTargetDataType>> | null;
+    private eventsForListener : string[];
+
     constructor() {
       super();
+      this.eventListenerCollectors = null;
+      this.eventsForListener = eventTypes;
     }
 
-    connectedCallback() {
+    connectedCallback(): void {
       this.render();
+      this.init();
+      this.initEvent();
     }
 
-    render() {
+    render(): void {
       this.innerHTML = `
                   <div class="audi-app-container">
                     <header-component></header-component>
                     <editor-modal type='source' title='소스 불러오기'></editor-modal>
                     <audi-main></audi-main>
+                    <editor-modal type="effect"></editor-modal>
                   </div>
               `;
     }
+
+    init(): void{
+      this.eventListenerCollectors = this.eventsForListener
+        .reduce((acc, cur)=> acc.set(cur, new Map()), new Map());
+    }
+
+    initEvent(): void{
+      this.eventsForListener.forEach((eventName)=>
+        this.addEventListener(eventName, this.eventListenerForRegistrant.bind(this))
+      );
+    }
+
+    eventListenerForRegistrant(e) {
+      const { target } = e;
+      
+      if (!this.isEventTarget(target) || !this.eventListenerCollectors) return;
+      
+      const eventType = e.type;
+      const eventKey = target.getAttribute('event-key');
+      
+      this.excuteEventListenerForTarget(eventType, eventKey, e);
+    }
+
+    isEventTarget(eventTarget: HTMLElement): Boolean {
+      const eventKey = eventTarget.getAttribute('event-key');
+      return (eventKey)? true : false;
+    }
+
+    excuteEventListenerForTarget(eventType: string, eventKey: string, e:Event){
+      if(!this.eventListenerCollectors) return;
+
+      const eventListenerCollector = this.eventListenerCollectors.get(eventType);
+      if(eventListenerCollector){
+        const eventTargetData = eventListenerCollector.get(eventKey);    
+        eventTargetData?.listener.call(eventTargetData.bindObj, e);
+      }
+    }
+
+    registerEventListener(eventData: EventDataType){
+      const { eventTypes, eventKey, listeners, bindObj } = eventData;
+
+      eventTypes.forEach((eventType, idx)=>{
+        if (this.eventListenerCollectors &&this.eventListenerCollectors.has(eventType)){
+          const eventListenerCollector = this.eventListenerCollectors.get(eventType);
+          if(eventListenerCollector){
+            eventListenerCollector.set(eventKey, {listener:listeners[idx],bindObj:bindObj});
+            this.eventListenerCollectors.set(eventType, eventListenerCollector);
+          }
+        }
+      });
+    }
   };
+
   customElements.define('audi-app', App);
 })();
 

--- a/frontend/src/components/EffectList/EffectList.scss
+++ b/frontend/src/components/EffectList/EffectList.scss
@@ -1,0 +1,31 @@
+@use '@style/variables.scss' as variables;
+
+audi-effect-list:not(:defined) {
+    display: hidden;
+}
+
+audi-effect-list{
+    width: 100%;
+}
+
+.effect-list-container{
+    width: 100%;
+
+    li{
+        display: flex;
+        width: 100%;
+        padding: 7px 5px;
+        margin-bottom: 10px;
+        border: 1px solid #ffffff;
+        cursor: pointer;
+
+        &:hover{
+            color: variables.$green-color;
+            border-color: variables.$green-color;
+        }
+
+        &:last-of-type{
+            margin-bottom: 0;
+        }
+    }
+}

--- a/frontend/src/components/EffectList/EffectList.ts
+++ b/frontend/src/components/EffectList/EffectList.ts
@@ -13,7 +13,7 @@ import "./EffectList.scss";
       this.render();
     }
 
-    render() {
+    render(): void {
       this.innerHTML = `
                   <ul class="effect-list-container">
                     ${this.getEffectList()}

--- a/frontend/src/components/EffectList/EffectList.ts
+++ b/frontend/src/components/EffectList/EffectList.ts
@@ -1,0 +1,33 @@
+import "./EffectList.scss";
+
+(() => {
+  const EffectList = class extends HTMLElement {
+    private effects: string[];
+
+    constructor() {
+      super();
+      this.effects = ['Gain', 'Fade in', 'Fade out', 'Compressor'];
+    }
+
+    connectedCallback() {
+      this.render();
+    }
+
+    render() {
+      this.innerHTML = `
+                  <ul class="effect-list-container">
+                    ${this.getEffectList()}
+                  </ul>
+              `;
+    }
+
+    getEffectList(): string{
+        return this.effects.reduce((acc,effect)=>
+            acc +=`<li><span>${effect}</span></li>` ,'');
+    }
+  };
+  customElements.define('audi-effect-list', EffectList);
+})();
+
+export {};
+

--- a/frontend/src/components/SourceUploadForm/SourceUploadForm.scss
+++ b/frontend/src/components/SourceUploadForm/SourceUploadForm.scss
@@ -7,10 +7,17 @@ $greenColor: #03c75a;
   flex-direction: column;
   justify-content: center;
 
-  width: 90%;
+  width: 100%;
   height: 40vh;
 
   border: 1px solid $borderColor;
+
+  .source-empty:hover{
+    *{
+      cursor: pointer;
+      color: $greenColor;
+    }
+  }
 }
 
 .hide-source-upload-content {

--- a/frontend/src/components/SourceUploadForm/SourceUploadForm.ts
+++ b/frontend/src/components/SourceUploadForm/SourceUploadForm.ts
@@ -1,4 +1,4 @@
-import './style.scss';
+import './SourceUploadForm.scss';
 import Analyzer from '../audio-analyzer';
 
 (() => {

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -10,6 +10,5 @@ import './Sidebar/Sidebar';
 import './SourceList/SourceList';
 import './TimeInfo/TimeInfo';
 import './Main/Main';
-import './modal';
-import './modal/modal-buttons';
-import './source-upload';
+import './Modal';
+import './SourceUploadForm/SourceUploadForm';

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -12,3 +12,4 @@ import './TimeInfo/TimeInfo';
 import './Main/Main';
 import './Modal';
 import './SourceUploadForm/SourceUploadForm';
+import './EffectList/EffectList';

--- a/frontend/src/components/modal/Modal.scss
+++ b/frontend/src/components/modal/Modal.scss
@@ -39,7 +39,7 @@ $greenColor: #03c75a;
   align-items: center;
 
   width: 50%;
-  height: 60%;
+  padding: 2% 5%;
 
   color: #ffffff;
   background-color: $baseColor;
@@ -47,6 +47,12 @@ $greenColor: #03c75a;
   border-radius: 5px;
 
   text-align: center;
+
+  .modal-title{
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 20px;
+  }
 }
 
 .modal-component {
@@ -58,6 +64,7 @@ modal-buttons {
 
 .source-upload-buttons {
   @extend %modal-buttons;
+  width: 100%;
 
   .modal-green-button {
     @extend %modal-button;

--- a/frontend/src/components/modal/Modal.ts
+++ b/frontend/src/components/modal/Modal.ts
@@ -1,5 +1,7 @@
 import { modalContents } from './modalContents';
 import { ModalType, ModalTitleType }  from "./modalType/modalType";
+import { registerEventToRoot } from "@util";
+import { EventType } from "@types";
 import './Modal.scss';
 
 (() => {
@@ -36,12 +38,13 @@ import './Modal.scss';
         this.type = newVal;  
         this[attrName] = newVal;
         this.render();
+        this.initElement();
       }
     }
 
     render() {
       this.innerHTML = `
-        <div id=${this.type} class='modal'>
+        <div id=${this.type} class='modal' event-key='modal'>
           <div class='modal-content'>
               <span class="modal-title">${this.title}</span>
               ${modalContents[this.type]}
@@ -56,7 +59,12 @@ import './Modal.scss';
     }
 
     initEvent(){
-      this.addEventListener('click', this.modalClickListener.bind(this));
+      registerEventToRoot({
+        eventTypes:[EventType.click], 
+        eventKey: 'modal', 
+        listeners:[this.modalClickListener], 
+        bindObj: this 
+      });
     }
 
     modalClickListener(e): void {

--- a/frontend/src/components/modal/Modal.ts
+++ b/frontend/src/components/modal/Modal.ts
@@ -42,7 +42,7 @@ import './Modal.scss';
       }
     }
 
-    render() {
+    render(): void {
       this.innerHTML = `
         <div id=${this.type} class='modal' event-key='modal'>
           <div class='modal-content'>
@@ -53,12 +53,12 @@ import './Modal.scss';
         </div>`;
     }
 
-    initElement(){
+    initElement(): void{
       this.modalElement = this.querySelector('.modal');
       this.modalCloseButton = this.querySelector('.modal-close-button');
     }
 
-    initEvent(){
+    initEvent(): void{
       registerEventToRoot({
         eventTypes:[EventType.click], 
         eventKey: 'modal', 
@@ -71,7 +71,7 @@ import './Modal.scss';
       this.hideModal();
     }
 
-    hideModal(){
+    hideModal(): void{
       this.modalElement?.classList.add('hide');
     }
   };

--- a/frontend/src/components/modal/Modal.ts
+++ b/frontend/src/components/modal/Modal.ts
@@ -1,13 +1,19 @@
-import { ModalContentType } from './modalContentType';
+import { modalContents } from './modalContents';
+import { ModalType, ModalTitleType }  from "./modalType/modalType";
 import './Modal.scss';
+
 (() => {
   const Modal = class extends HTMLElement {
-    public type: string;
+    public type: ModalType;
+    private modalElement: HTMLDivElement | null;
+    private modalCloseButton: HTMLButtonElement | null;
 
     constructor() {
       super();
-      this.type = 'source';
-      this.title = '소스 불러오기';
+      this.type = ModalType.none;
+      this.title = '';
+      this.modalElement = null;
+      this.modalCloseButton = null;
     }
 
     static get observedAttributes() {
@@ -16,22 +22,20 @@ import './Modal.scss';
 
     connectedCallback() {
       this.render();
-      addEventListener('click', this.closeModal.bind(this));
+      this.initElement();
+      this.initEvent();
     }
 
     attributeChangedCallback(attrName, oldVal, newVal) {
       if (oldVal !== newVal) {
+        switch(attrName){
+          case 'type':
+            this.title = ModalTitleType[`${newVal}`];
+            break;
+        }
+        this.type = newVal;  
         this[attrName] = newVal;
-      }
-    }
-
-    closeModal(e): void {
-      const { target } = e;
-      const modalElement: HTMLElement | null = document.querySelector('.modal');
-      const modalCloseButton: HTMLElement | null = document.querySelector('.modal-close-button');
-
-      if (modalElement && (target === modalElement || target === modalCloseButton)) {
-        modalElement.style.display = 'none';
+        this.render();
       }
     }
 
@@ -40,10 +44,27 @@ import './Modal.scss';
         <div id=${this.type} class='modal'>
           <div class='modal-content'>
               <span class="modal-title">${this.title}</span>
-              ${ModalContentType[this.type]}
+              ${modalContents[this.type]}
               <modal-buttons type=${this.type}></modal-buttons>
           </div>
         </div>`;
+    }
+
+    initElement(){
+      this.modalElement = this.querySelector('.modal');
+      this.modalCloseButton = this.querySelector('.modal-close-button');
+    }
+
+    initEvent(){
+      this.addEventListener('click', this.modalClickListener.bind(this));
+    }
+
+    modalClickListener(e): void {
+      this.hideModal();
+    }
+
+    hideModal(){
+      this.modalElement?.classList.add('hide');
     }
   };
   customElements.define('editor-modal', Modal);

--- a/frontend/src/components/modal/Modal.ts
+++ b/frontend/src/components/modal/Modal.ts
@@ -1,5 +1,5 @@
-import { modalContents } from './modalContents';
-import './style.scss';
+import { ModalContentType } from './modalContentType';
+import './Modal.scss';
 (() => {
   const Modal = class extends HTMLElement {
     public type: string;
@@ -39,8 +39,8 @@ import './style.scss';
       this.innerHTML = `
         <div id=${this.type} class='modal'>
           <div class='modal-content'>
-              <h2>${this.title}</h2>
-              ${modalContents[this.type]}
+              <span class="modal-title">${this.title}</span>
+              ${ModalContentType[this.type]}
               <modal-buttons type=${this.type}></modal-buttons>
           </div>
         </div>`;

--- a/frontend/src/components/modal/ModalButtons/ModalButtons.ts
+++ b/frontend/src/components/modal/ModalButtons/ModalButtons.ts
@@ -33,7 +33,7 @@ import { modalButtonContents } from './modalButtonContents';
       this.changeBtnStyle();
     }
 
-    render() {
+    render(): void {
       this.innerHTML = `
         <section class='source-upload-buttons'>
             ${modalButtonContents[this.type]}
@@ -41,11 +41,11 @@ import { modalButtonContents } from './modalButtonContents';
         `;
     }
 
-    initElement(){
+    initElement(): void{
       this.closeButtonElement = this.querySelector('.modal-close-button');
     }
 
-    changeBtnStyle(){
+    changeBtnStyle(): void{
       if (this.type === 'effect' && this.closeButtonElement) {
         this.closeButtonElement.style.marginLeft = '0rem';
       }

--- a/frontend/src/components/modal/ModalButtons/ModalButtons.ts
+++ b/frontend/src/components/modal/ModalButtons/ModalButtons.ts
@@ -1,4 +1,4 @@
-import { modalButtons } from './modalButtons';
+import { modalButtonType } from './modalButtonType';
 
 (() => {
   const ModalButtons = class extends HTMLElement {
@@ -26,7 +26,7 @@ import { modalButtons } from './modalButtons';
     render() {
       this.innerHTML = `
         <section class='source-upload-buttons'>
-            ${modalButtons[this.type]}
+            ${modalButtonType[this.type]}
         </section>
         `;
     }

--- a/frontend/src/components/modal/ModalButtons/ModalButtons.ts
+++ b/frontend/src/components/modal/ModalButtons/ModalButtons.ts
@@ -1,34 +1,54 @@
-import { modalButtonType } from './modalButtonType';
+import { modalButtonContents } from './modalButtonContents';
 
 (() => {
   const ModalButtons = class extends HTMLElement {
     private type: string;
+    private closeButtonElement: HTMLButtonElement | null;
 
     constructor() {
       super();
       this.type = 'source';
+      this.closeButtonElement = null; 
     }
 
     static get observedAttributes() {
       return ['type'];
     }
 
+    attributeChangedCallback(attrName, oldVal, newVal) {
+      if (oldVal !== newVal) {
+        switch(attrName){
+          case 'type':
+            this.type = newVal;
+            break;
+        }
+        this[attrName] = newVal;
+        this.render();
+      }
+    }
+
     connectedCallback() {
       this.render();
-
-      const closeButtonElement: HTMLElement | null = document.querySelector('.modal-close-button');
-
-      if (this.type === 'effect' && closeButtonElement) {
-        closeButtonElement.style.marginLeft = '0rem';
-      }
+      this.initElement();
+      this.changeBtnStyle();
     }
 
     render() {
       this.innerHTML = `
         <section class='source-upload-buttons'>
-            ${modalButtonType[this.type]}
+            ${modalButtonContents[this.type]}
         </section>
         `;
+    }
+
+    initElement(){
+      this.closeButtonElement = this.querySelector('.modal-close-button');
+    }
+
+    changeBtnStyle(){
+      if (this.type === 'effect' && this.closeButtonElement) {
+        this.closeButtonElement.style.marginLeft = '0rem';
+      }
     }
   };
   customElements.define('modal-buttons', ModalButtons);

--- a/frontend/src/components/modal/ModalButtons/modalButtonContents.ts
+++ b/frontend/src/components/modal/ModalButtons/modalButtonContents.ts
@@ -1,9 +1,6 @@
-interface ModalButtonType{
-  source: string;
-  effect: string;
-}
+import { ModalButtonType } from "../modalType/modalType"
 
-const modalButtonType: ModalButtonType = {
+const modalButtonContents: ModalButtonType = {
   source: `
     <button class='modal-green-button' type='button'>불러오기</button>
     <button class='modal-close-button' type='button'>취소</button>`,
@@ -11,5 +8,5 @@ const modalButtonType: ModalButtonType = {
 };
 
 export {
-  modalButtonType
+  modalButtonContents
 }; 

--- a/frontend/src/components/modal/ModalButtons/modalButtonType.ts
+++ b/frontend/src/components/modal/ModalButtons/modalButtonType.ts
@@ -1,6 +1,15 @@
-export const modalButtons = {
+interface ModalButtonType{
+  source: string;
+  effect: string;
+}
+
+const modalButtonType: ModalButtonType = {
   source: `
     <button class='modal-green-button' type='button'>불러오기</button>
     <button class='modal-close-button' type='button'>취소</button>`,
   effect: `<button class='modal-close-button' type='button'>취소</button>`
 };
+
+export {
+  modalButtonType
+}; 

--- a/frontend/src/components/modal/index.js
+++ b/frontend/src/components/modal/index.js
@@ -1,0 +1,2 @@
+import './ModalButtons/ModalButtons';
+import './Modal';

--- a/frontend/src/components/modal/modalContentType.ts
+++ b/frontend/src/components/modal/modalContentType.ts
@@ -1,7 +1,0 @@
-interface ModalContentType{
-  source: string;
-}
-
-export const ModalContentType: ModalContentType = {
-  source: '<source-upload-form class=modal-component></source-upload-form>'
-};

--- a/frontend/src/components/modal/modalContentType.ts
+++ b/frontend/src/components/modal/modalContentType.ts
@@ -1,0 +1,7 @@
+interface ModalContentType{
+  source: string;
+}
+
+export const ModalContentType: ModalContentType = {
+  source: '<source-upload-form class=modal-component></source-upload-form>'
+};

--- a/frontend/src/components/modal/modalContents.ts
+++ b/frontend/src/components/modal/modalContents.ts
@@ -1,3 +1,0 @@
-export const modalContents: object = {
-  source: '<source-upload-form class=modal-component></source-upload-form>'
-};

--- a/frontend/src/components/modal/modalContents.ts
+++ b/frontend/src/components/modal/modalContents.ts
@@ -1,0 +1,10 @@
+import { ModalContentType } from "./modalType/modalType";
+
+const modalContents: ModalContentType = {
+  source: '<source-upload-form class=modal-component></source-upload-form>',
+  effect: '<audi-effect-list></audi-effect-list>'
+};
+
+export {
+  modalContents
+}

--- a/frontend/src/components/modal/modalType/modalType.ts
+++ b/frontend/src/components/modal/modalType/modalType.ts
@@ -1,0 +1,27 @@
+enum ModalType {
+    none = '',
+    source = 'source',
+    effect = 'effect'
+}
+
+enum ModalTitleType{
+    source = '소스 불러오기',
+    effect = '이펙트 목록'
+}
+
+interface ModalContentType{
+    source : string;
+    effect : string;
+}
+
+interface ModalButtonType{
+    source: string;
+    effect: string;
+  }
+
+export {
+    ModalType,
+    ModalTitleType,
+    ModalContentType,
+    ModalButtonType
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,14 @@
     "isolatedModules": false,
     "noEmit": true,
     "noImplicitAny": false,
+    "baseUrl": ".",
+    "paths": {
+      "@components": ["src/components"],
+      "@style": ["src/common/style"],
+      "@util": ["src/common/util"],
+      "@types": ["src/common/types"]
+    }
+
   },
   "include": [
     "src"

--- a/frontend/webpack.config.common.js
+++ b/frontend/webpack.config.common.js
@@ -30,7 +30,8 @@ module.exports = (env) => {
       alias: {
         '@components': path.resolve(__dirname, 'src/components'),
         '@style': path.resolve(__dirname, 'src/common/style'),
-        '@util': path.resolve(__dirname, 'src/common/util')
+        '@util': path.resolve(__dirname, 'src/common/util'),
+        '@types': path.resolve(__dirname, 'src/common/types')
       }
     },
     entry: {


### PR DESCRIPTION
## 📕 제목

EffectList 컴포넌트 제작 및 루트 컴포넌트에서 모든 이벤트 처리 구현
관련이슈 #20 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

![캡처3](https://user-images.githubusercontent.com/32856129/100268351-383d2d80-2f98-11eb-9538-03df550bfe62.jpg)

![캡처2](https://user-images.githubusercontent.com/32856129/100270454-72f49500-2f9b-11eb-8148-c01ce0adbb88.jpg)

- [x] EffectList 컴포넌트 제작
- [x] Modal 컴포넌트 리팩토링
- [x] 루트 컴포넌트에서 모든 이벤트 처리 구현
   => 이제 이벤트 처리를 모두 루트에게 위임 가능합니다 :-) 
- [x] 타입스크립트 설정 파일에 alias 설정 추가 
   => 이제 ts 파일에서도 alias로 참조가능합니다 :-) 

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Modal 컴포넌트에 EffectList를 추가하면서 전체적으로 코드를 리팩토링 하게 되었습니다
  - 리팩토링 내용
    - 파일 네이밍을 파스칼 케이스로 변경
    - Modal 컴포넌트에서 type을 처리하는 부분을 작은 함수단위로 분리하여 코드 수정
    - Modal 컴포넌트에서 내부적으로 사용하는 요소들에 대한 Type 정의 및 분리
    - ModalContent의 내용이 왼쪽으로 치우쳐 있어서 부분적인 SCSS 수정
    - Modal 컴포넌트에서 type 속성을 상위 컴포넌트에서 전달받으면 값이 변함에 따라 리렌더링 하도록 수정
    - 리렌더링하는 과정에서 EventListener를 계속해서 등록해주거나, DOM을 다시 서치해야하는 이슈가 발생하여 모든 이벤트 처리를 루트 컴포넌트에서 처리하도록 구현
- App.ts(루트 컴포넌트 수정)
    - App.ts에서 하위 컴포넌트로 이벤트리스너를 전달받아 실행하도록 코드를 수정했습니다
    - EventUtil을 통해서 하위 컴포넌트에서 처리할 이벤트를 루트 컴포넌트에 전달하고, 루트 컴포넌트에서는 모든 이벤트를 가지고 있다가 특정 이벤트가 발생했을 때, 해당 이벤트 타겟 컴포넌트에서 등록한 리스너를 실행해주는 방식으로 동작합니다 :-)
    - 루트에 이벤트 리스너 등록과정 
      1) EventUtil 이용해 루트에서 이벤트 처리하기 위해 필요한 데이터를 전달
      2) 루트는 전달 받은 데이터를 바탕으로 이벤트타입(이벤트 종류....click, mouseover 등)을 분류하고, 해당 이벤트타입의 리스너 컬렉션에 이벤트 타겟을 식별할 수 있는 키와 함께 리스너를 등록합니다
      3) 이벤트 키는 이벤트 타겟 엘리먼트의 속성 값에도 지정해주어야하며 루트에 전달한 키와 동일해야합니다. 루트에서 이벤트 처리시 이벤트 키를 이용해서 등록한 리스너를 식별하고 실행합니다 :-)
     - 핵심 코드
```
  render(): void {
      this.innerHTML = `
        <div id='modal' class='modal' event-key='modal'>
          ....
        </div>`;
   }
// modal.ts
// 이벤트 타겟 앨리먼트에 event-key 속성을 지정해주어야합니다
// event-key는 유니크한 string 값이어야하며 루트에서 이값을 이용해 적절한 리스너를 실행시켜줍니다
```

```
   initEvent(): void{
        registerEventToRoot({
           eventTypes:[EventType.click], 
           eventKey: 'modal', 
           listeners:[this.modalClickListener], 
           bindObj: this 
      });
    }
// modal.ts
// registerEventToRoot는 루트에 이벤트를 등록하기위한 util 함수입니다
// eventTypes : EventType에 정의된 이벤트타입 배열,  배열인 이유는 이벤트리스너를 여러개 등록하기 위함
// eventKey : 루트에서 식별하기 위한 key
// listeners : eventTypes 배열에 1:1로 대응되는 리스너 함수 배열
// bindObj : 바인딩할 객체
``` 