### PR TITLE
 Modal 관련 컴포넌트 리팩토링

### DIFF
--- a/frontend/src/components/App/App.ts
+++ b/frontend/src/components/App/App.ts
@@ -1,5 +1,5 @@
-import "./App.scss";
-import { EventDataType, eventTypes, EventTargetDataType, StoreChannelType } from "@types";
+import './App.scss';
+import { EventDataType, eventTypes, EventTargetDataType, StoreChannelType } from '@types';
 
 (() => {
   const App = class extends HTMLElement {
@@ -22,7 +22,7 @@ import { EventDataType, eventTypes, EventTargetDataType, StoreChannelType } from
       this.innerHTML = `
                   <div class="audi-app-container">
                     <header-component></header-component>
-                    <editor-modal type='source' title='소스 불러오기'></editor-modal>
+                    <editor-modal type='source'></editor-modal>
                     <editor-modal type='download'></editor-modal>
                     <audi-main></audi-main>
                   </div>
@@ -30,14 +30,11 @@ import { EventDataType, eventTypes, EventTargetDataType, StoreChannelType } from
     }
 
     init(): void {
-      this.eventListenerCollectors = this.eventsForListener
-        .reduce((acc, cur) => acc.set(cur, new Map()), new Map());
+      this.eventListenerCollectors = this.eventsForListener.reduce((acc, cur) => acc.set(cur, new Map()), new Map());
     }
 
     initEvent(): void {
-      this.eventsForListener.forEach((eventName) =>
-        this.addEventListener(eventName, this.eventListenerForRegistrant.bind(this))
-      );
+      this.eventsForListener.forEach((eventName) => this.addEventListener(eventName, this.eventListenerForRegistrant.bind(this)));
     }
 
     eventListenerForRegistrant(e): void {
@@ -53,7 +50,7 @@ import { EventDataType, eventTypes, EventTargetDataType, StoreChannelType } from
 
     isEventTarget(eventTarget: HTMLElement): Boolean {
       const eventKey = eventTarget.getAttribute('event-key');
-      return (eventKey) ? true : false;
+      return eventKey ? true : false;
     }
 
     excuteEventListenerForTarget(eventType: string, eventKey: string, e: Event): void {
@@ -84,4 +81,4 @@ import { EventDataType, eventTypes, EventTargetDataType, StoreChannelType } from
   customElements.define('audi-app', App);
 })();
 
-export { };
+export {};

--- a/frontend/src/components/EditorMenu/EditorMenu.ts
+++ b/frontend/src/components/EditorMenu/EditorMenu.ts
@@ -1,5 +1,4 @@
 import './EditorMenu.scss';
-import { EventUtil } from "@util";
 
 (() => {
   const EditorMenu = class extends HTMLElement {
@@ -12,19 +11,20 @@ import { EventUtil } from "@util";
       this.initEvent();
     }
 
-    initEvent(){
+    initEvent() {
       this.addEventListener('click', this.openSourceUploadForm.bind(this));
       this.addEventListener('click', this.openSourceDownloadForm.bind(this));
-
     }
 
     openSourceUploadForm(e) {
       const { target } = e;
       const targetElement = target.closest('#upload');
       const uploadElement = document.getElementById('upload');
-      const modalElement = document.querySelector('editor-modal');
-      
-      if (modalElement && targetElement === uploadElement) {
+
+      if (targetElement === uploadElement) {
+        const uploadModalElement = document.getElementById('source');
+        const modalElement = uploadModalElement.closest('editor-modal');
+
         modalElement.showModal();
       }
     }
@@ -34,10 +34,12 @@ import { EventUtil } from "@util";
       const targetElement = target.closest('#save');
       if (!targetElement) return;
       const downloadModal = document.getElementById('save');
-      const sourceDownloadModalElement: HTMLElement | null = document.getElementById('download');
 
-      if (sourceDownloadModalElement && targetElement === downloadModal) {
-        sourceDownloadModalElement.style.display = 'flex';
+      if (targetElement === downloadModal) {
+        const downloadModalElement = document.getElementById('download');
+        const modalElement = downloadModalElement.closest('editor-modal');
+
+        modalElement.showModal();
       }
     }
 
@@ -65,4 +67,4 @@ import { EventUtil } from "@util";
   customElements.define('editor-menu', EditorMenu);
 })();
 
-export { };
+export {};

--- a/frontend/src/components/SourceDownload/SourceDownload.ts
+++ b/frontend/src/components/SourceDownload/SourceDownload.ts
@@ -1,7 +1,7 @@
-import { registerEventToRoot } from "@util";
-import { EventType } from "@types";
-import { saveFile } from '@util'
-import './SourceDownload.scss'
+import { EventUtil } from '@util';
+import { EventType } from '@types';
+import { saveFile } from '@util';
+import './SourceDownload.scss';
 
 (() => {
   const SourceDownload = class extends HTMLElement {
@@ -10,19 +10,18 @@ import './SourceDownload.scss'
     constructor() {
       super();
       this.downloadModal = null;
-      this.formElement = null
+      this.formElement = null;
       this.saveButton = null;
     }
 
     connectedCallback() {
       this.render();
       this.initElement();
-      // this.initEvent();
+      this.initEvent();
       console.log('click');
 
       this.saveButton?.addEventListener('click', this.onSubmitHandler);
       this.formElement?.addEventListener('keyup', this.onChangeHandler);
-
     }
 
     initElement(): void {
@@ -31,20 +30,34 @@ import './SourceDownload.scss'
     }
 
     initEvent(): void {
-      registerEventToRoot({
+      EventUtil.registerEventToRoot({
         eventTypes: [EventType.click, EventType.keyup],
         eventKey: 'save',
         listeners: [this.onSubmitHandler, this.onChangeHandler],
         bindObj: this
       });
+
+      EventUtil.registerEventToRoot({
+        eventTypes: [EventType.click],
+        eventKey: 'download-modal-close',
+        listeners: [this.modalCloseBtnClickListener],
+        bindObj: this
+      });
+    }
+
+    modalCloseBtnClickListener(): void {
+      const typeModalElement = document.getElementById('download');
+      const modalElement = typeModalElement.closest('editor-modal');
+
+      modalElement?.hideModal();
     }
 
     onSubmitHandler = async (e) => {
       const fileNmae = `${this.formElement?.fileName.value}.${this.formElement?.extention.value}`;
       const quality = this.formElement?.quality.value;
       if (this.saveButton) {
-        this.saveButton.innerText = '압축 중'
-        this.disabeldButton(this.saveButton)
+        this.saveButton.innerText = '압축 중';
+        this.disabeldButton(this.saveButton);
 
         // test용 음원파일
         const URL = 'https://s3-us-west-2.amazonaws.com/s.cdpn.io/123941/Yodel_Sound_Effect.mp3';
@@ -52,36 +65,36 @@ import './SourceDownload.scss'
         const arrayBuffer = await response.arrayBuffer();
 
         // arrayBuffer만 있으면 됨
-        await saveFile(arrayBuffer, quality, fileNmae)
+        await saveFile(arrayBuffer, quality, fileNmae);
 
-        this.saveButton.innerText = '저장하기'
+        this.saveButton.innerText = '저장하기';
         this.abeldButton(this.saveButton);
       }
-    }
+    };
 
     onChangeHandler = (e) => {
       if (this.saveButton) {
         if (this.formElement?.fileName.value.length > 0) {
-          this.abeldButton(this.saveButton)
+          this.abeldButton(this.saveButton);
           this.saveButton.addEventListener('click', this.onSubmitHandler);
         } else {
           console.log(this.formElement?.fileName.value.length);
 
           this.disabeldButton(this.saveButton);
-          this.saveButton.removeEventListener('click', this.onSubmitHandler)
+          this.saveButton.removeEventListener('click', this.onSubmitHandler);
         }
       }
-    }
+    };
 
     abeldButton = (button) => {
-      button.style.backgroundColor = "#03c75a";
+      button.style.backgroundColor = '#03c75a';
       button.disabled = false;
-    }
+    };
 
     disabeldButton = (button) => {
-      button.style.backgroundColor = "#212121";
+      button.style.backgroundColor = '#212121';
       button.disabled = true;
-    }
+    };
 
     render() {
       this.innerHTML = `
@@ -118,10 +131,11 @@ import './SourceDownload.scss'
                   </label>
                 </div>
               </form>
+              <modal-buttons type='download'></modal-buttons>
             `;
     }
   };
   customElements.define('audi-source-download', SourceDownload);
-})()
+})();
 
-export { };
+export {};

--- a/frontend/src/components/SourceUploadForm/SourceUploadForm.ts
+++ b/frontend/src/components/SourceUploadForm/SourceUploadForm.ts
@@ -1,10 +1,10 @@
 import './SourceUploadForm.scss';
 import { FileUtil, AudioUtil } from '@util';
-import { Source } from "@model";
+import { Source } from '@model';
 import { Controller } from '@controllers';
-import { EventUtil } from "@util";
-import { EventType } from "@types";
- 
+import { EventUtil } from '@util';
+import { EventType } from '@types';
+
 (() => {
   const SourceUploadForm = class extends HTMLElement {
     private filename: string;
@@ -24,7 +24,7 @@ import { EventType } from "@types";
       this.initEvent();
     }
 
-    reset(){
+    reset() {
       this.filename = '';
       this.source = null;
       this.render();
@@ -41,6 +41,7 @@ import { EventType } from "@types";
                     <div>Click or Drag and Drop</div>
                 </label>
             </section>
+            <modal-buttons type=source></modal-buttons>
             `;
     }
 
@@ -54,18 +55,32 @@ import { EventType } from "@types";
       this.addEventListener('change', this.uploadFileListener.bind(this));
 
       EventUtil.registerEventToRoot({
-        eventTypes:[EventType.click], 
-        eventKey: 'source-upload', 
-        listeners:[this.uploadBtnClickListener], 
-        bindObj: this 
+        eventTypes: [EventType.click],
+        eventKey: 'source-upload',
+        listeners: [this.uploadBtnClickListener],
+        bindObj: this
+      });
+
+      EventUtil.registerEventToRoot({
+        eventTypes: [EventType.click],
+        eventKey: 'source-modal-close',
+        listeners: [this.modalCloseBtnClickListener],
+        bindObj: this
       });
     }
 
-    uploadBtnClickListener(e){
-      if(!this.source){ 
+    modalCloseBtnClickListener(): void {
+      const typeModalElement = document.getElementById('source');
+      const modalElement = typeModalElement.closest('editor-modal');
+
+      modalElement?.hideModal();
+    }
+
+    uploadBtnClickListener(e) {
+      if (!this.source) {
         alert('소스를 등록해주세요.');
         return;
-      };
+      }
 
       //로드중입니다....
       Controller.addSource(this.source);
@@ -74,7 +89,7 @@ import { EventType } from "@types";
       this.reset();
     }
 
-    uploadFormDragOverListener(e){
+    uploadFormDragOverListener(e) {
       e.preventDefault();
       const { target } = e;
       if (this.sourceUploadElement && e.type === 'dragover' && target === this.sourceUploadElement) {
@@ -105,7 +120,7 @@ import { EventType } from "@types";
       const audioBuffer = await AudioUtil.decodeArrayBufferToAudio(arrayBuffer);
       this.source = new Source(file, audioBuffer);
     }
-    
+
     setFilename(filename) {
       this.filename = filename;
       this.render();

--- a/frontend/src/components/modal/Modal.ts
+++ b/frontend/src/components/modal/Modal.ts
@@ -1,7 +1,7 @@
 import { modalContents } from './modalContents';
-import { ModalType, ModalTitleType }  from "./modalType/modalType";
-import { EventUtil } from "@util";
-import { EventType } from "@types";
+import { ModalType, ModalTitleType } from './modalType/modalType';
+import { EventUtil } from '@util';
+import { EventType } from '@types';
 import './Modal.scss';
 
 (() => {
@@ -17,7 +17,7 @@ import './Modal.scss';
     }
 
     static get observedAttributes() {
-      return ['type', 'title'];
+      return ['type'];
     }
 
     connectedCallback() {
@@ -28,9 +28,9 @@ import './Modal.scss';
 
     attributeChangedCallback(attrName, oldVal, newVal) {
       if (oldVal !== newVal) {
-        switch(attrName){
+        switch (attrName) {
           case 'type':
-            this.type = newVal;  
+            this.type = newVal;
             break;
         }
         this[attrName] = newVal;
@@ -45,49 +45,36 @@ import './Modal.scss';
           <div class='modal-content'>
               <span class="modal-title">${this.title}</span>
               ${modalContents[this.type]}
-              <modal-buttons type=${this.type}></modal-buttons>
           </div>
         </div>`;
     }
 
-    initElement(): void{
+    initElement(): void {
       this.modalElement = this.querySelector('.modal');
     }
 
-    initEvent(): void{
+    initEvent(): void {
       EventUtil.registerEventToRoot({
-        eventTypes:[EventType.click], 
-        eventKey: this.type, 
-        listeners:[this.modalClickListener], 
-        bindObj: this 
+        eventTypes: [EventType.click],
+        eventKey: this.type,
+        listeners: [this.modalClickListener],
+        bindObj: this
       });
-
-      EventUtil.registerEventToRoot({
-        eventTypes:[EventType.click], 
-        eventKey: 'modal-close', 
-        listeners:[this.modalCloseBtnClickListener], 
-        bindObj: this 
-      });
-    }
-
-    modalCloseBtnClickListener(e): void{
-      this.hideModal();
     }
 
     modalClickListener(e): void {
       this.hideModal();
     }
 
-    showModal(): void{
+    showModal(): void {
       this.modalElement?.classList.remove('hide');
     }
 
-    hideModal(): void{
+    hideModal(): void {
       this.modalElement?.classList.add('hide');
     }
-  }
+  };
   customElements.define('editor-modal', Modal);
 })();
 
 export {};
-

--- a/frontend/src/components/modal/ModalButtons/modalButtonContents.ts
+++ b/frontend/src/components/modal/ModalButtons/modalButtonContents.ts
@@ -1,14 +1,12 @@
-import { ModalButtonType } from "../modalType/modalType"
+import { ModalButtonType } from '../modalType/modalType';
 
 const modalButtonContents: ModalButtonType = {
   source: `
     <button class='modal-green-button' event-key='source-upload' type='button'>불러오기</button>
-    <button class='modal-close-button' event-key='modal-close' type='button'>취소</button>`,
+    <button class='modal-close-button' event-key='source-modal-close' type='button'>취소</button>`,
   effect: `<button class='modal-close-button' event-key='modal-close' type='button'>취소</button>`,
   download: `<a class="compress-button" id="download-link" ><button class="save-button" type='button' disabled='disabled'>변환</button></a>
-    <button class='modal-close-button' type='button'>취소</button>`
+    <button class='modal-close-button' event-key='download-modal-close' type='button'>취소</button>`
 };
 
-export {
-  modalButtonContents
-}; 
+export { modalButtonContents };


### PR DESCRIPTION
## 📕 제목

Modal 관련 컴포넌트 리팩토링

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] ModalButtons를 각 modal-content 안에 넣어줬습니다.
- [x] 소스 불러오기, 파일 저장하기 아이콘을 누르면 그에 맞는 모달창이 뜨도록 했습니다. 
- [x] 각 modal-content에 모달이 닫히는 이벤트를 등록해줬습니다. 

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 같은 event-key를 등록해주니 하나의 모달만 창이 닫히게 되어 '<각 타입>-modal-close'형식으로 취소 버튼에 event-key를 등록했습니다.
- 같은 화면에 여러개의 editor-modal을 불러오니 하나만 인식을 하네요... modal의 id가 특정 값인 DOM을 탐색한 후 그때의 Element에서 가장 가까운 editor-modal을 탐색했습니다. 
- 가까운 editor-modal을 탐색한 element의 showModal 함수를 불러왔습니다. 