### PR TITLE
파일저장 mp3 인코딩 기능 추가 및 컴포넌트 리팩토링

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8936,6 +8936,14 @@
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
       "dev": true
     },
+    "lamejs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lamejs/-/lamejs-1.2.0.tgz",
+      "integrity": "sha1-Aln4PbRmYUGntnG4yqY2nZUXfQg=",
+      "requires": {
+        "use-strict": "1.0.1"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12660,6 +12668,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-strict": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
+      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
     },
     "util": {
       "version": "0.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
+    "lamejs": "^1.2.0",
     "typescript": "^4.0.5"
   },
   "devDependencies": {

--- a/frontend/src/common/types/CompressorOption.ts
+++ b/frontend/src/common/types/CompressorOption.ts
@@ -1,0 +1,9 @@
+import { createTypeOperatorNode } from "typescript"
+
+interface CompressorOption {
+  fileName: string,
+  extention: string,
+  quality: number | null
+}
+
+export { CompressorOption }

--- a/frontend/src/common/types/eventTypes.ts
+++ b/frontend/src/common/types/eventTypes.ts
@@ -5,6 +5,7 @@ enum EventKeyType {
     SOURCE_DOWNLOAD_FILE_NAME_KEYUP = 'SOURCE_DOWNLOAD_FILE_NAME_KEYUP',
     SOURCE_DOWNLOAD_SAVE_BTN_CLICK = 'SOURCE_DOWNLOAD_SAVE_BTN_CLICK',
     SOURCE_DOWNLOAD_CLOSE_BTN_CLICK = 'SOURCE_DOWNLOAD_CLOSE_BTN_CLICK',
+    SOURCE_DOWNLOAD_EXTENTION_CHANGE = 'SOURCE_DOWNLOAD_EXTENTION_CHANGE',
     EDITOR_MENU_OPEN_UPLOAD_BTN_CLICK = 'EDITOR_MENU_OPEN_UPLOAD_BTN_CLICK',
     EDITOR_MENU_OPEN_DOWNLOAD_BTN_CLICK = 'EDITOR_MENU_OPEN_DOWNLOAD_BTN_CLICK',
     EFFECT_LIST_CLOSE_BTN_CLICK = 'EFFECT_LIST_CLOSE_BTN_CLICK'
@@ -20,12 +21,12 @@ enum EventType {
 
 const eventTypes = ['click', 'keyup', 'dragover', 'drop', 'change'];
 
-interface EventTargetDataType{
+interface EventTargetDataType {
     listener: EventListener;
     bindObj: Object;
 }
 
-interface EventDataType{
+interface EventDataType {
     eventTypes: EventType[];
     eventKey: string;
     listeners: EventListener[];

--- a/frontend/src/common/types/index.js
+++ b/frontend/src/common/types/index.js
@@ -3,3 +3,4 @@ export { StoreChannelType, StoreStateType, StoreObserverData } from "./storeType
 export { ModalStateType, ModalType, ModalTitleType, ModalContentType, ModalButtonContentType } from "./modalTypes";
 export { ButtonType } from './buttonType';
 export { IconType } from './iconType';
+export { CompressorOption } from './CompressorOption';

--- a/frontend/src/common/util/compressor.ts
+++ b/frontend/src/common/util/compressor.ts
@@ -1,19 +1,38 @@
-export const saveFile = async (arrayBuffer: ArrayBuffer, quality: number, fileName: string) => {
+import { CompressorOption } from '@types';
+import * as lamejs from 'lamejs';
+
+export const saveFile = async (arrayBuffer: ArrayBuffer, options: CompressorOption) => {
   const audioCtx: AudioContext = new AudioContext();
   const buffer = await audioCtx.decodeAudioData(arrayBuffer);
+  const name = `${options.fileName}.${options.extention}`;
+
+  const wavBuffer = await makeWaveBlob(buffer);
+
+  if (options.extention === 'wav') {
+    const wavFile = new Blob([wavBuffer], { type: `audio/wav` });
+    makeDownload(wavFile, name);
+  } else if (options.extention === 'mp3' && options.quality) {
+    const mp3Blob = await makeMP3(wavBuffer, options.quality);
+    makeDownload(mp3Blob, name);
+  }
+}
+
+const makeWaveBlob = async (buffer: AudioBuffer) => {
   const offlineAudioCtx: OfflineAudioContext = new OfflineAudioContext({
     numberOfChannels: 2,
-    length: (buffer.sampleRate * quality) * buffer.duration,
-    sampleRate: buffer.sampleRate * quality,
+    length: (44100) * buffer.duration,
+    sampleRate: 44100,
   });
   const soundSource = offlineAudioCtx.createBufferSource();
   soundSource.buffer = buffer;
+
   const compressor = offlineAudioCtx.createDynamicsCompressor();
   compressor.threshold.setValueAtTime(-20, offlineAudioCtx.currentTime);
   compressor.knee.setValueAtTime(30, offlineAudioCtx.currentTime);
   compressor.ratio.setValueAtTime(5, offlineAudioCtx.currentTime);
   compressor.attack.setValueAtTime(.05, offlineAudioCtx.currentTime);
   compressor.release.setValueAtTime(.25, offlineAudioCtx.currentTime);
+
   const gainNode = offlineAudioCtx.createGain();
   gainNode.gain.setValueAtTime(1, offlineAudioCtx.currentTime);
   soundSource.connect(compressor);
@@ -21,56 +40,98 @@ export const saveFile = async (arrayBuffer: ArrayBuffer, quality: number, fileNa
   gainNode.connect(offlineAudioCtx.destination);
   soundSource.start(0);
   soundSource.loop = false;
+
   const renderedBuffer = await offlineAudioCtx.startRendering();
-  makeDownload(renderedBuffer, offlineAudioCtx.length, fileName);
+  return bufferToWave(renderedBuffer, offlineAudioCtx.length);
 }
-const makeDownload = (abuffer: AudioBuffer, total_samples: number, fileName: string) => {
-  const extention = fileName.split('.')[1];
-  const newFile = URL.createObjectURL(bufferToWave(abuffer, total_samples, extention));
-  const downloadLink: HTMLElement | null = document.getElementById("download-link");
-  downloadLink?.setAttribute('href', newFile);
-  downloadLink?.setAttribute('download', fileName);
-}
-const bufferToWave = (abuffer: AudioBuffer, len: number, extention: string) => {
+
+const bufferToWave = (abuffer: AudioBuffer, len: number) => {
   const numOfChan: number = abuffer.numberOfChannels;
   const length: number = len * numOfChan * 2 + 44;
   const buffer: ArrayBuffer = new ArrayBuffer(length);
-  const view: DataView = new DataView(buffer);
+  const view: DataView = new DataView(buffer);     // buffer를 다룰 때 사용
   const channels: Float32Array[] = [];
   let sample: number = 0;
   let offset: number = 0;
   let pos: number = 0;
+
+  // 부호없는 16비트로 정수로 변환
   const setUint16 = (data) => {
     view.setUint16(pos, data, true);
     pos += 2;
   }
+
+  // 부호없는 32비트로 정수로 변환
   const setUint32 = (data) => {
     view.setUint32(pos, data, true);
     pos += 4;
   }
-  setUint32(0x46464952);
-  setUint32(length - 8);
-  setUint32(0x45564157);
-  setUint32(0x20746d66);
-  setUint32(16);
-  setUint16(1);
+
+  // wav 파일의 헤더구조
+  setUint32(0x46464952);                              // "RIFF"
+  setUint32(length - 8);                              // file length - 8
+  setUint32(0x45564157);                              // "WAVE"
+
+  setUint32(0x20746d66);                              // "fmt " chunk
+  setUint32(16);                                      // length = 16
+  setUint16(1);                                       // PCM (uncompressed)
   setUint16(numOfChan);
   setUint32(abuffer.sampleRate);
-  setUint32(abuffer.sampleRate * 2 * numOfChan);
-  setUint16(numOfChan * 2);
-  setUint16(16);
-  setUint32(0x61746164);
-  setUint32(length - pos - 4);
+  setUint32(abuffer.sampleRate * 2 * numOfChan);      // avg. bytes/sec
+  setUint16(numOfChan * 2);                           // block-align
+  setUint16(16);                                      // 16-bit (hardcoded in this demo)
+
+  setUint32(0x61746164);                              // "data" - chunk
+  setUint32(length - pos - 4);                        // chunk length
+
   for (let i = 0; i < abuffer.numberOfChannels; i++)
     channels.push(abuffer.getChannelData(i));
+
   while (pos < length) {
     for (let i = 0; i < numOfChan; i++) {
       sample = Math.max(-1, Math.min(1, channels[i][offset]));
       sample = (0.5 + sample < 0 ? sample * 32768 : sample * 32767) | 0;
-      view.setInt16(pos, sample, true);
+      view.setInt16(pos, sample, true);               // 부호있는 16비트 정수로 변환
       pos += 2;
     }
     offset++
   }
-  return new Blob([buffer], { type: `audio/${extention}` });
+
+  return buffer;
+}
+
+const makeMP3 = async (wavBuffer: ArrayBuffer, quality: number) => {
+  const mp3Data: Int8Array[] = [];
+
+  const mp3encoder = new lamejs.Mp3Encoder(2, 44100, quality);
+
+  const wavHdr = lamejs.WavHeader.readHeader(new DataView(wavBuffer));
+  const wavSamples = new Int16Array(wavBuffer, wavHdr.dataOffset, wavHdr.dataLen / 2);
+
+  //Stereo
+  const leftData: number[] = [];
+  const rightData: number[] = [];
+  for (let i = 0; i < wavSamples.length; i += 2) {
+    leftData.push(wavSamples[i]);
+    rightData.push(wavSamples[i + 1]);
+  }
+  const mp3buf = mp3encoder?.encodeBuffer(leftData, rightData);
+  if (mp3buf.length > 0) {
+    mp3Data.push(mp3buf);//new Int8Array(mp3buf));
+  }
+  const d = mp3encoder?.flush();
+
+  if (d.length > 0) {
+    mp3Data.push(new Int8Array(d));
+  }
+
+  return new Blob(mp3Data, { type: 'audio/mp3' });
+}
+
+const makeDownload = (newFile: Blob, fileName: string) => {
+  const audioFile = URL.createObjectURL(newFile);
+  const downloadLink: HTMLElement | null = document.getElementById("download-link");
+
+  downloadLink?.setAttribute('href', audioFile);
+  downloadLink?.setAttribute('download', fileName);
 }

--- a/frontend/src/components/Modal/ModalContents/SourceDownload/SourceDownload.scss
+++ b/frontend/src/components/Modal/ModalContents/SourceDownload/SourceDownload.scss
@@ -44,7 +44,7 @@ audi-source-download:not(:defined) {
 }
 
 .radios{
-
+  display:block;
   label {
     margin-right: 2rem;
   }
@@ -68,4 +68,8 @@ audi-source-download:not(:defined) {
       background-color: variables.$green-color;
     }
   }
+}
+
+.visible-hidden {
+  visibility: hidden;
 }

--- a/frontend/src/components/Modal/ModalContents/SourceDownload/SourceDownload.ts
+++ b/frontend/src/components/Modal/ModalContents/SourceDownload/SourceDownload.ts
@@ -1,5 +1,5 @@
 import { EventUtil } from '@util';
-import { EventType, EventKeyType, ModalType, ButtonType } from '@types';
+import { EventType, EventKeyType, ModalType, ButtonType, CompressorOption } from '@types';
 import { saveFile } from '@util';
 import { Controller } from '@controllers';
 import './SourceDownload.scss';
@@ -9,12 +9,14 @@ import './SourceDownload.scss';
     private formElement: HTMLFormElement | null;
     private saveButton: HTMLButtonElement | null;
     private downloadLink: HTMLElement | null;
+    private qualityRadios: HTMLDivElement | null;
 
     constructor() {
       super();
       this.formElement = null;
       this.saveButton = null;
       this.downloadLink = null;
+      this.qualityRadios = null;
     }
 
     connectedCallback(): void {
@@ -24,8 +26,8 @@ import './SourceDownload.scss';
       this.reset();
     }
 
-    reset(): void{
-      if(!this.downloadLink || !this.formElement || !this.saveButton) return;
+    reset(): void {
+      if (!this.downloadLink || !this.formElement || !this.saveButton) return;
 
       this.downloadLink.removeAttribute('href');
       this.downloadLink.removeAttribute('download');
@@ -39,32 +41,32 @@ import './SourceDownload.scss';
               <form class="download-form">
                 <div class="file-name">
                   <h4>파일 이름</h4>
-                  <input id="fileName" type="text" name="fileName" required event-key=${EventKeyType.SOURCE_DOWNLOAD_FILE_NAME_KEYUP} />
-                </div>
-                <div class="radios">
-                  <h4>해상도</h4>
-                  <label>
-                    <input type="radio" name="quality" value=0.5></input>
-                    저
-                  </label>
-                  <label>
-                    <input type="radio" name="quality" value=0.75></input>
-                    중
-                  </label>
-                  <label>
-                    <input type="radio" name="quality" value=1 checked></input>
-                    고
-                  </label>
+                  <input id="fileName" type="text" name="fileName" event-key=${EventKeyType.SOURCE_DOWNLOAD_FILE_NAME_KEYUP} />
                 </div>
                 <div class="radios">
                   <h4>확장자</h4>
                   <label>
-                    <input type="radio" name="extention" value="mp3"></input>
-                    .mp3
+                    <input type="radio" name="extention" value="mp3" event-key=${EventKeyType.SOURCE_DOWNLOAD_EXTENTION_CHANGE}></input>
+                    mp3
                   </label>
                   <label>
-                    <input type="radio" name="extention" value="wav" checked></input>
-                    .wav
+                    <input type="radio" name="extention" value="wav" checked event-key=${EventKeyType.SOURCE_DOWNLOAD_EXTENTION_CHANGE}></input>
+                    wav (44.1kHz)
+                  </label>
+                </div>
+                <div class="radios quality-radios visible-hidden">
+                  <h4>해상도</h4>
+                  <label>
+                    <input type="radio" name="quality" value=128 checked event-key=${EventKeyType.SOURCE_DOWNLOAD_EXTENTION_CHANGE}></input>
+                    128kbps
+                  </label>
+                  <label>
+                    <input type="radio" name="quality" value=192 event-key=${EventKeyType.SOURCE_DOWNLOAD_EXTENTION_CHANGE}></input>
+                    192kbps
+                  </label>
+                  <label>
+                    <input type="radio" name="quality" value=256 event-key=${EventKeyType.SOURCE_DOWNLOAD_EXTENTION_CHANGE}></input>
+                    256kbps
                   </label>
                 </div>
               </form>
@@ -81,6 +83,7 @@ import './SourceDownload.scss';
       this.formElement = document.querySelector('.download-form');
       this.saveButton = document.querySelector('.save-button');
       this.downloadLink = document.getElementById("download-link");
+      this.qualityRadios = document.querySelector('.quality-radios');
     }
 
     initEvent(): void {
@@ -99,6 +102,13 @@ import './SourceDownload.scss';
       });
 
       EventUtil.registerEventToRoot({
+        eventTypes: [EventType.change],
+        eventKey: EventKeyType.SOURCE_DOWNLOAD_EXTENTION_CHANGE,
+        listeners: [this.extentionChangeListener],
+        bindObj: this
+      });
+
+      EventUtil.registerEventToRoot({
         eventTypes: [EventType.click],
         eventKey: EventKeyType.SOURCE_DOWNLOAD_CLOSE_BTN_CLICK,
         listeners: [this.modalCloseBtnClickListener],
@@ -107,26 +117,30 @@ import './SourceDownload.scss';
     }
 
     async modalFormSubmitListener(e) {
-      if(!this.saveButton || !this.formElement) return; 
+      if (!this.saveButton || !this.formElement || !this.downloadLink) return;
 
-      const fileName = `${this.formElement?.fileName.value}.${this.formElement?.extention.value}`;
-      const quality = this.formElement?.quality.value;
+      if (this.downloadLink.getAttribute('href')) return;
 
+      const compressorObject: CompressorOption = {
+        fileName: this.formElement.fileName.value,
+        extention: this.formElement.extention.value,
+        quality: this.formElement.extention.value === 'mp3' ? this.formElement.quality.value : null
+      };
       this.changeBtnValue('압축 중');
       this.inactiveSaveButton(this.saveButton);
-        
+
       const URL = 'https://s3-us-west-2.amazonaws.com/s.cdpn.io/123941/Yodel_Sound_Effect.mp3';
       const response = await window.fetch(URL);
       const arrayBuffer = await response.arrayBuffer();
-        
-      await saveFile(arrayBuffer, quality, fileName);
+
+      await saveFile(arrayBuffer, compressorObject);
       this.changeBtnValue('저장하기');
-        
+
       this.activeSaveButton(this.saveButton);
     };
 
-    changeBtnValue(value: string): void{      
-      if(!this.saveButton) return;     
+    changeBtnValue(value: string): void {
+      if (!this.saveButton) return;
       this.saveButton.value = value;
     }
 
@@ -135,18 +149,37 @@ import './SourceDownload.scss';
       Controller.changeModalState(ModalType.download, true);
     }
 
-    fileNameChangeListener(e): void {    
+    fileNameChangeListener(e): void {
       if (!this.saveButton) return;
       this.saveButtonActivationHandler();
     };
 
+    extentionChangeListener(e): void {
+      const { target } = e;
+
+      if (!this.formElement || !this.qualityRadios || !(target.name === 'extention' || target.name === 'quality')) return;
+
+      const fileName = this.formElement.fileName.value;
+      this.reset();
+      this.formElement.fileName.value = fileName;
+      this.saveButtonActivationHandler()
+
+      if (target.name === 'extention') {
+        if (target.value === 'mp3') {
+          this.qualityRadios.classList.remove('visible-hidden')
+        } else {
+          this.qualityRadios.classList.add('visible-hidden')
+        }
+      }
+    }
+
     saveButtonActivationHandler(): void {
-      if(!this.saveButton || !this.formElement) return;
+      if (!this.saveButton || !this.formElement) return;
 
       if (this.formElement.fileName.value.length > 0) {
         this.activeSaveButton(this.saveButton);
         return;
-      } 
+      }
       this.inactiveSaveButton(this.saveButton);
     }
 


### PR DESCRIPTION
## 📕 제목

파일저장 mp3 인코딩 기능 추가
관련이슈 #22 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] lamejs 라이브러리 설치
- [x] mp3 확장자를 선택했을 때 해상도 radio가 보이도록 리팩토링
- [x] radio들의 change 이벤트를 위한 `SOURCE_DOWNLOAD_EXTENTION_CHANGE` 이벤트키 추가
- [x] mp3 인코딩 기능 추가
  - mp3 인코딩은 AudioBuffer -> wave ->mp3 순으로 진행됨 

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 커밋에서 인수 -> 인자 오타네요...
- 다들 pull 받아서 사용할 때 `npm install` 꼭 해주세요
