### PR TITLE
AudioTrackSection 구간에 따른 파형 정보 그리기 및 코드 리팩토링

### DIFF
--- a/frontend/src/common/types/eventTypes.ts
+++ b/frontend/src/common/types/eventTypes.ts
@@ -12,7 +12,8 @@ enum EventKeyType {
     EFFECT_GAIN_INPUT_PERCENTAGE = 'EFFECT_GAIN_INPUT_PERCENTAGE',
     SOURCE_LIST_DRAGSTART = 'SOURCE_LIST_DRAGSTART',
     AUDIO_TRACK_DRAGOVER_DROP = 'AUDIO_TRACK_DRAGOVER_DROP',
-    PLAYBAR_MULTIPLE = 'PLAYBAR_MULTIPLE'
+    PLAYBAR_MULTIPLE = 'PLAYBAR_MULTIPLE',
+    SOURCE_LIST_MULTIPLE = 'SOURCE_LIST_MULTIPLE'
 }
 
 enum EventType {
@@ -23,13 +24,14 @@ enum EventType {
     dragover = 'dragover',
     dragenter = 'dragenter',
     dragleave = 'dragleave',
+    dragend = 'dragend',
     drop = 'drop',
     change = 'change',
     input = 'input',
     mousemove = 'mousemove'
 }
 
-const eventTypes = ['click', 'dblclick', 'keyup', 'dragstart', 'dragover', 'dragenter','dragleave','drop', 'change', 'input', 'mousemove'];
+const eventTypes = ['click', 'dblclick', 'keyup', 'dragstart', 'dragover', 'dragenter','dragleave','drop', 'change', 'input', 'mousemove', 'dragend'];
 
 interface EventTargetDataType {
   listener: EventListener;

--- a/frontend/src/common/util/AudioUtil.ts
+++ b/frontend/src/common/util/AudioUtil.ts
@@ -19,31 +19,32 @@ const mergeChannels = async (audioBuffer) => {
   return renderBuffer;
 }
 
-const parsePeaks = (audioBuffer: AudioBuffer): Promise<number[]> => new Promise((resolve, reject)=> {
-    const {duration, numberOfChannels, sampleRate, length } = audioBuffer;
-    const sampleSize = length / sampleRate;
+const parsePeaks = (audioBuffer: AudioBuffer, parsedBufferSize: number): Promise<number[]> => new Promise((resolve, reject)=> {
+    const {length } = audioBuffer;
+    const sampleSize = length / parsedBufferSize;
     const sampleStep = Math.floor(sampleSize / 10) || 1;
-    const channelPeaks :Float32Array = audioBuffer.getChannelData(0);
-    let resultPeaks: number[] = []; 
+    
+    const channelData :Float32Array = audioBuffer.getChannelData(0);
+    let parsedData: number[] = []; 
 
-    Array(sampleRate).fill(0).forEach((v, newPeakIndex) => {
+    Array(parsedBufferSize).fill(0).forEach((v, newPeakIndex) => {
       const start = Math.floor(newPeakIndex * sampleSize);
       const end = Math.floor(start + sampleSize);
-      let min = channelPeaks[0];
-      let max = channelPeaks[0];
+      let min = channelData[0];
+      let max = channelData[0];
 
-      for (let sampleIndex = start; sampleIndex < end; sampleIndex += sampleStep) { //480
-        const v = channelPeaks[sampleIndex];
+      for (let sampleIndex = start; sampleIndex < end; sampleIndex += sampleStep) {
+        const v = channelData[sampleIndex];
 
         if (v > max) max = v;
         else if (v < min) min = v;
       }
 
-      resultPeaks[2 * newPeakIndex] = max;
-      resultPeaks[2 * newPeakIndex + 1] = min;
+      parsedData[2 * newPeakIndex] = max;
+      parsedData[2 * newPeakIndex + 1] = min;
     });
     
-    resolve(resultPeaks);
+    resolve(parsedData);
   });
 
 export {

--- a/frontend/src/components/AudioTrack/AudioTrack.scss
+++ b/frontend/src/components/AudioTrack/AudioTrack.scss
@@ -14,6 +14,7 @@ audi-audio-track:not(:defined) {
 
     .audio-track-area{
         display: flex;
+        flex-wrap: nowrap;
         padding: 10px 0px;
         position: relative;
         width: 100%;
@@ -43,7 +44,7 @@ audi-audio-track:not(:defined) {
         margin-bottom: 0;
     }
 
-    .audio-track-massage{
+    .audio-track-message{
         position: absolute;
         top: 50%;
         left: 50%;

--- a/frontend/src/components/AudioTrack/AudioTrack.ts
+++ b/frontend/src/components/AudioTrack/AudioTrack.ts
@@ -100,7 +100,6 @@ import "./AudioTrack.scss";
           trackStartTime : 0
         });
 
-        Controller.changeTrackDragState(false);
         Controller.addTrackSection(this.trackId, trackSection);
         this.hideMessage();
       }

--- a/frontend/src/components/AudioTrack/AudioTrack.ts
+++ b/frontend/src/components/AudioTrack/AudioTrack.ts
@@ -51,7 +51,7 @@ import "./AudioTrack.scss";
                     <div class="audio-track-container">
                       <div class="audio-track-area">
                         ${this.getTrackSectionList()}
-                        <div class="audio-track-massage"><span>Drag & Drop</span></div>
+                        <div class="audio-track-message"><span>Drag & Drop</span></div>
                         <div class="audio-track-dropzone hide" event-key=${EventKeyType.AUDIO_TRACK_DRAGOVER_DROP + this.trackId}></div>
                       </div>      
                     </div>
@@ -119,11 +119,11 @@ import "./AudioTrack.scss";
       }
 
       subscribe(): void {
-        storeChannel.subscribe(StoreChannelType.TRACK_DRAG_STATE_CHANNEL, this.trackDragStateObesever, this);
-        storeChannel.subscribe(StoreChannelType.TRACK_SECTION_LIST_CHANNEL, this.trackSectionListObserver, this);
+        storeChannel.subscribe(StoreChannelType.TRACK_DRAG_STATE_CHANNEL, this.trackDragStateObserverCallback, this);
+        storeChannel.subscribe(StoreChannelType.TRACK_SECTION_LIST_CHANNEL, this.trackSectionListObserverCallback, this);
       }
 
-      trackDragStateObesever(isTrackDraggable): void {
+      trackDragStateObserverCallback(isTrackDraggable): void {
         if(isTrackDraggable){
           this.activeTrackDropzone();
           return;
@@ -139,7 +139,7 @@ import "./AudioTrack.scss";
         this.trackDropzoneElement?.classList.add('hide');
       }
 
-      trackSectionListObserver({trackId, trackSectionList}): void {
+      trackSectionListObserverCallback({trackId, trackSectionList}): void {
         if(trackId !== this.trackId) return;
 
         this.trackSectionList = trackSectionList;

--- a/frontend/src/components/AudioTrack/AudioTrack.ts
+++ b/frontend/src/components/AudioTrack/AudioTrack.ts
@@ -65,7 +65,7 @@ import "./AudioTrack.scss";
       }
 
       initElement(): void {
-        this.trackMessage = this.querySelector('.audio-track-massage');
+        this.trackMessage = this.querySelector('.audio-track-message');
         this.trackDropzoneElement = this.querySelector('.audio-track-dropzone');
       }
 
@@ -90,13 +90,15 @@ import "./AudioTrack.scss";
         const source = Controller.getSourceBySourceId(Number(sourceId));
         if(!source) return;
 
+        const { duration } = source;
+
         const trackSection = new TrackSection({ 
           sourceId : source.id, 
           trackId: this.trackId,
           channelStartTime : 0, 
-          channelEndTime : 0, 
+          channelEndTime : duration, 
           parsedChannelStartTime : 0,
-          parsedChannelEndTime: 10,
+          parsedChannelEndTime: duration,
           trackStartTime : 0
         });
 

--- a/frontend/src/components/AudioTrack/AudioTrack.ts
+++ b/frontend/src/components/AudioTrack/AudioTrack.ts
@@ -60,7 +60,7 @@ import "./AudioTrack.scss";
 
       getTrackSectionList(): string {
         return this.trackSectionList.reduce((acc, trackSection, idx) => 
-          acc += `<audi-track-section data-id=${trackSection.sourceId} data-track-id=${trackSection.trackId}></audi-track-section>`, 
+          acc += `<audi-track-section data-id=${trackSection.id} data-track-id=${trackSection.trackId}></audi-track-section>`, 
         "");
       }
 
@@ -98,7 +98,8 @@ import "./AudioTrack.scss";
           parsedChannelStartTime : 0,
           parsedChannelEndTime: 10,
           trackStartTime : 0
-       });
+        });
+
         Controller.changeTrackDragState(false);
         Controller.addTrackSection(this.trackId, trackSection);
         this.hideMessage();

--- a/frontend/src/components/AudioTrack/AudioTrackSection/AudioTrackSection.ts
+++ b/frontend/src/components/AudioTrack/AudioTrackSection/AudioTrackSection.ts
@@ -1,23 +1,28 @@
 import { Controller } from "@controllers";
 import "./AudioTrackSection.scss";
 
+interface SectionData{
+  sectionChannelData: number[];
+  duration: number; 
+}
+
 (() => {
    const AudioTrackSection = class extends HTMLElement {
         private trackId: number;
         private sectionId: number;
-        private sectionChannelData: number[] | undefined;
+        private sectionData: SectionData | undefined;
         private trackCanvasElement: HTMLCanvasElement | undefined | null;
 
         constructor(){
             super();
             this.trackId = 0;
             this.sectionId = 0;
-            this.sectionChannelData;
+            this.sectionData;
             this.trackCanvasElement;
         }
 
         static get observedAttributes(): string[] {
-          return ['data-id'];
+          return ['data-id', 'data-track-id'];
         }
   
         attributeChangedCallback(attrName: string, oldVal: string, newVal: string): void {
@@ -52,30 +57,33 @@ import "./AudioTrackSection.scss";
 
         init(): void {
           this.trackCanvasElement = this.querySelector<HTMLCanvasElement>('.audio-track-section');
-          this.sectionChannelData = Controller.getSectionChannelData(this.trackId, this.sectionId);
+          this.sectionData = Controller.getSectionChannelData(this.trackId, this.sectionId);
         }
 
-        draw(): void {         
-          if(!this.sectionChannelData || !this.trackCanvasElement) return;
+        draw(): void {        
+          if(!this.sectionData || !this.trackCanvasElement) return;
 
+          const { sectionChannelData, duration } = this.sectionData;
+          
           const canvasWidth = this.trackCanvasElement.clientWidth;
           this.trackCanvasElement.width = canvasWidth;
-
+          this.trackCanvasElement.style.width = `${canvasWidth / (300/duration)}px`;
+    
           const canvasHeight = this.trackCanvasElement.clientHeight;
           const canvasCtx = this.trackCanvasElement.getContext('2d');
           if(!canvasCtx) return;
 
           const middleHeight = canvasHeight / 2;
-          const defaultLineWidth = 1;  
+          const defaultLineWidth =1;
 
           canvasCtx.strokeStyle = '#2196f3';
-          canvasCtx.lineWidth = defaultLineWidth / (48000 / canvasWidth);
+          canvasCtx.lineWidth = defaultLineWidth / (37500 / canvasWidth);
           canvasCtx.beginPath();
 
           let offsetX = 0;
           let offsetY;
-          for(let i = 0; i < this.sectionChannelData.length; i++){
-            offsetY = middleHeight + Math.floor((this.sectionChannelData[i]*canvasHeight)/2);
+          for(let i = 0; i < sectionChannelData.length; i++){
+            offsetY = middleHeight + Math.floor((sectionChannelData[i]*canvasHeight)/2);
             if(i % 2 == 0)
               canvasCtx.moveTo(offsetX, offsetY);
             else{

--- a/frontend/src/components/AudioTrack/AudioTrackSection/AudioTrackSection.ts
+++ b/frontend/src/components/AudioTrack/AudioTrackSection/AudioTrackSection.ts
@@ -65,24 +65,26 @@ interface SectionData{
 
           const { sectionChannelData, duration } = this.sectionData;
           
-          const canvasWidth = this.trackCanvasElement.clientWidth;
+          const trackWidth = this.trackCanvasElement.clientWidth;
+          const canvasWidth = trackWidth / (300/duration);
           this.trackCanvasElement.width = canvasWidth;
-          this.trackCanvasElement.style.width = `${canvasWidth / (300/duration)}px`;
+          this.trackCanvasElement.style.width = `${canvasWidth}px`;
     
           const canvasHeight = this.trackCanvasElement.clientHeight;
           const canvasCtx = this.trackCanvasElement.getContext('2d');
           if(!canvasCtx) return;
 
+          const numOfPeaks = sectionChannelData.length;
           const middleHeight = canvasHeight / 2;
           const defaultLineWidth =1;
 
           canvasCtx.strokeStyle = '#2196f3';
-          canvasCtx.lineWidth = defaultLineWidth / (37500 / canvasWidth);
+          canvasCtx.lineWidth = defaultLineWidth / ((numOfPeaks/2) / canvasWidth);
           canvasCtx.beginPath();
 
           let offsetX = 0;
           let offsetY;
-          for(let i = 0; i < sectionChannelData.length; i++){
+          for(let i = 0; i < numOfPeaks; i++){
             offsetY = middleHeight + Math.floor((sectionChannelData[i]*canvasHeight)/2);
             if(i % 2 == 0)
               canvasCtx.moveTo(offsetX, offsetY);

--- a/frontend/src/components/Modal/ModalContents/SourceUpload/SourceUpload.ts
+++ b/frontend/src/components/Modal/ModalContents/SourceUpload/SourceUpload.ts
@@ -137,8 +137,8 @@ import './SourceUpload.scss';
       const audioBuffer = await AudioUtil.decodeArrayBufferToAudio(arrayBuffer);
       const mergedBuffer = await AudioUtil.mergeChannels(audioBuffer);
       const channelData = mergedBuffer.getChannelData(0);
-      const parsedChannelData = await AudioUtil.parsePeaks(mergedBuffer);
-
+      const parsedChannelData = await AudioUtil.parsePeaks(mergedBuffer, 7500);
+      
       this.source = new Source(file, audioBuffer, parsedChannelData, channelData);
     }
 

--- a/frontend/src/components/SourceList/SourceList.ts
+++ b/frontend/src/components/SourceList/SourceList.ts
@@ -22,8 +22,8 @@ import "./SourceList.scss";
 
     getSources(): string {
       return this.sourceList.reduce((acc, source) =>
-        acc + `<li class="audio-source" draggable="true" data-id=${source.id} event-key=${EventKeyType.SOURCE_LIST_DRAGSTART}>
-                        <span event-key=${EventKeyType.SOURCE_LIST_DRAGSTART}>${source.fileName}</span>
+        acc + `<li class="audio-source" draggable="true" data-id=${source.id} event-key=${EventKeyType.SOURCE_LIST_MULTIPLE}>
+                        <span event-key=${EventKeyType.SOURCE_LIST_MULTIPLE}>${source.fileName}</span>
                         <ul class="source-info">
                           <li><span>FileName: ${source.fileName}</span></li>
                           <li><span>FileSize: ${this.parseFileSize(source.fileSize)}</span></li>
@@ -70,9 +70,9 @@ import "./SourceList.scss";
 
     initEvent(): void{
       EventUtil.registerEventToRoot({
-        eventTypes: [EventType.dragstart],
-        eventKey: EventKeyType.SOURCE_LIST_DRAGSTART,
-        listeners: [this.sourceListDragstartListener],
+        eventTypes: [EventType.dragstart, EventType.dragend],
+        eventKey: EventKeyType.SOURCE_LIST_MULTIPLE,
+        listeners: [this.sourceListDragstartListener, this.sourceListDragendListener],
         bindObj: this
       })
     }
@@ -80,7 +80,12 @@ import "./SourceList.scss";
     sourceListDragstartListener(e): void{
       e.dataTransfer.setData("text/plain", e.target.dataset.id);
       e.dataTransfer.dropEffect = "link";
+
       Controller.changeTrackDragState(true);
+    }
+
+    sourceListDragendListener(e): void{
+      Controller.changeTrackDragState(false);
     }
 
     subscribe(): void{

--- a/frontend/src/controllers/controller.ts
+++ b/frontend/src/controllers/controller.ts
@@ -2,30 +2,35 @@ import { Source, Track, TrackSection } from '@model';
 import { store } from "@store";
 import { ModalType } from "@types";
 
-const getSectionChannelData = (trackId: number, trackSectionId: number): number[] | undefined => { 
+interface SectionData{
+    sectionChannelData: number[];
+    duration: number; 
+}
+
+const getSectionChannelData = (trackId: number, trackSectionId: number): SectionData | undefined => { 
     const { trackList, sourceList } = store.getState();
     const track = trackList.find((track) => (track.id === trackId));
-    // console.log(track);
     if(!track) return;
     
     const { trackSectionList } = track;
     const trackSection = trackSectionList.find((trackSection) => (trackSection.id === trackSectionId));
-    // console.log(trackSection);
     if(!trackSection) return;
 
     const source = sourceList.find((source) => (source.id === trackSection.sourceId));
-    // console.log(source);
     if(!source) return;
 
-    const { channelData, parsedChannelData, duration, length, sampleRate } = source;
+    const { parsedChannelData, duration } = source;
     const { parsedChannelStartTime, parsedChannelEndTime } = trackSection;
-    console.log("channelData", channelData);
-    console.log("parsedChannelData", parsedChannelData);
-    console.log("duration", duration);
-    console.log("length", length);
-    console.log("sampleRate", sampleRate);
+    const numOfPeakPerSecond = parsedChannelData.length / duration;
+    
+    const sectionChannelStartTime = numOfPeakPerSecond * parsedChannelStartTime;
+    const sectionChannelEndTime = numOfPeakPerSecond * parsedChannelEndTime;
+    const sectionChannelData = parsedChannelData.slice(sectionChannelStartTime, sectionChannelEndTime);
 
-    return parsedChannelData;
+    return {
+        sectionChannelData: sectionChannelData,
+        duration: parsedChannelEndTime - parsedChannelStartTime
+    };
 }
 
 const getSourceBySourceId = (sourceId: number): Source | undefined => {


### PR DESCRIPTION
## 📕 제목

AudioTrackSection 구간에 따른 파형 정보 그리기 및 코드 리팩토링
관련이슈 #18, #79

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 버그 수정
  - 소스에서 트랙으로 드래그앤드랍시 한 파일만 불러와지는 버그 수정
![ezgif com-gif-maker (17)](https://user-images.githubusercontent.com/32856129/100957732-5e496b80-355e-11eb-828d-a6e8e539729a.gif)

  - 소스에서 드래그앤드랍으로 트랙 드랍존 활성화 이후, 트랙에서 드랍해야만 드랍존 활성화가 해제되는 버그 수정
![ezgif com-gif-maker (16)](https://user-images.githubusercontent.com/32856129/100957629-28a48280-355e-11eb-9dc4-771b75ee0b32.gif)

  - 클래스네이밍, 함수네이밍 오타 수정 및 변경
- [x] 전체 트랙의 너비를 5분으로 고려한 각 트랙 섹션의 너비 설정
  - 현재 트랙섹션이 하나만 존재할 때는 비율이 맞게 설정되지만, 여러 트랙섹션이 트랙에 있을 때, 비율이 깨지는 버그 발생 ㅠ (수정예정)
- [x] AudioUtil parsePeaks 함수 구현완료
  - AudioUtil parsePeaks 함수는 AudioBuffer의 피크 값을 압축해주는 함수입니다
  - 함수의 인자로 오디오 버퍼와 parsedBufferSize(압축해서 반환받을 버퍼의 사이즈)를 넘기면 전체 피크내용을 parsedBufferSize 만큼의 길이를 가진 오디오 버퍼로 압축해서 반환합니다
```
  const parsePeaks = (audioBuffer: AudioBuffer, parsedBufferSize: number) : Promise<number[]> => ...(생략)
  ....  
 
  AudioUtil.parsePeaks(audioBuffer, 30000);  //audioBuffer를 길이가 30000개인 버퍼로 압축합니다
```

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 트랙 및 트랙 섹션의 id값을 증가하는 부분은 원석님이 수정하셔서 반영하지 않았습니다 :-)
- 트랙섹션이 추가될 때, 너비조정이 현재 제대로 동작되고 있지않습니다! (수정예정)
- 파일이 모두 머지되면 트랙섹션과 트랙의 오버플로우를 적용해서 스크롤이 가능하게 수정할 예정입니다!
- 현재 화면의 사이즈가 변경되면 캔버스가 다시 그려지지 않아서 트랙 섹션의 비율이 깨지는데, 트랙이 화면사이즈에 따라 반응형으로 다시 그려지도록 수정할 예정입니다!
- 빈 트랙의 사이즈가 조금 다른데 해당 부분도 수정하겠습니다!!
