### PR TITLE
마커 종료시점 이동 및 오디오 반복 재생 구현, 앞으로 건너뛰기 버그 수정

### DIFF
--- a/frontend/src/components/Marker/Marker.ts
+++ b/frontend/src/components/Marker/Marker.ts
@@ -33,8 +33,11 @@ import { StoreChannelType } from '@types';
         return;
       }
 
-      //0이 아닐 때는 더하는 식으로 진행된다.
-      //하지만.. 마지막 위치일 때는 더해지면 안된다고..
+      if(newCurrentPosition[1] === 1) {
+        markerElement.style.left = `${newCurrentPosition[0]}px`;
+        return;
+      }
+
       const prevCurrentPosition = Number(markerElement?.style.left.split('px')[0]);
       let currentPosition = prevCurrentPosition + newCurrentPosition;
       if (currentPosition < 0) currentPosition = 0;

--- a/frontend/src/controllers/controller.ts
+++ b/frontend/src/controllers/controller.ts
@@ -279,7 +279,7 @@ const getIsPauseState = (): boolean => {
   return isPause;
 };
 
-const setMarkerWidth = (markerWidth: number): void => {
+const setMarkerWidth = (markerWidth: number|number[]): void => {
   store.setMarkerWidth(markerWidth);
 };
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -184,7 +184,7 @@ const store = new (class Store {
     this.state = { ...this.state, isPause: isPauseState };
   }
 
-  setMarkerWidth(newMarkerWidth: number): void {
+  setMarkerWidth(newMarkerWidth: number|number[]): void {
     storeChannel.publish(StoreChannelType.CURRENT_POSITION_CHANNEL, newMarkerWidth);
   }
 


### PR DESCRIPTION
## 📕 제목

마커 종료시점 이동 및 오디오 반복 재생 구현
관련이슈 #24, #29, #111

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 버튼을 누르거나 단축키 ]를 누를 시 마커가 종료시점으로 이동한다.
- [x] 반복재생이 아닐 때 마커가 종료시점에 다다르면 일시정지 상태가 된다.
- [x] 오디오 반복재생 버튼을 누르면 맨 처음부터 종료시점까지 오디오가 반복 재생된다.
- [x] 앞으로 건너뛰기 시 waitTime이  잘못 설정 된 부분 수정.

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 종료시점으로 이동하기 위해 marker 위치를 구할 때 AudioTrack에 있던 calculateTrackWidth 함수를 그대로 가져와 사용했습니다. 함수 자체를 따로 빼는 게 좋을 것 같습니다.
- setMarkerWidth 관련해서 보낸 값을 기존 값과 더하는 것이 아닌, 보낸 값으로 바로 설정할 수 있도록 하기 위해 인자를 수정했습니다. 
    - 현재 number 배열을 보냈을 때 배열의 두 번째 원소가 1이라면 첫 번째 원소를 width로 설정하도록 해두었습니다. 후에 수정이 좀 더 필요해 보입니다.
- 현재 loop의 시작지점, 끝지점을 설정하는 부분이 스크롤 등과 연결돼있지 않아 loop의 시작을 0으로, 끝을 가장 긴 길이로 설정해두었습니다.
