### PR TITLE
트랙 추가하기 커맨드 수정 및 트랙 삭제하기 커맨드 구현

### DIFF
--- a/frontend/src/common/command/AddTrackCommand.ts
+++ b/frontend/src/common/command/AddTrackCommand.ts
@@ -11,17 +11,13 @@ class AddTrackCommand extends Command {
 
     execute(){
         try{
-            this.addNewTrack();
+            const newTrack = new Track({id: 0, trackSectionList: []});
+            Controller.setTrack(newTrack);
+
+            this.publishNewTrackList();
         }catch(e){
             console.log(e);
         }
-    }
-
-    addNewTrack(): void {
-        const newTrack = new Track({id: 0, trackSectionList: []});
-        Controller.setTrack(newTrack);
-
-        this.publishNewTrackList();
     }
 
     undo(){
@@ -35,7 +31,6 @@ class AddTrackCommand extends Command {
 
     publishNewTrackList(): void {
         const newTrackList = Controller.getTrackList();
-        console.log(newTrackList);
 
         storeChannel.publish(StoreChannelType.TRACK_CHANNEL, newTrackList);
         storeChannel.publish(StoreChannelType.TRACK_LIST_CHANNEL, newTrackList);

--- a/frontend/src/common/command/AddTrackCommand.ts
+++ b/frontend/src/common/command/AddTrackCommand.ts
@@ -11,28 +11,33 @@ class AddTrackCommand extends Command {
 
     execute(){
         try{
-            const newTrack = new Track({id: 0, trackSectionList: []});
-            Controller.setTrack(newTrack);
-
-            const newTrackList = Controller.getTrackList();
-            this.publishNewTrackList(newTrackList);
+            this.addNewTrack();
         }catch(e){
             console.log(e);
         }
+    }
+
+    addNewTrack(): void {
+        const newTrack = new Track({id: 0, trackSectionList: []});
+        Controller.setTrack(newTrack);
+
+        this.publishNewTrackList();
     }
 
     undo(){
         try{
-            const trackList = Controller.getTrackList();
-            trackList.pop();
-
-            this.publishNewTrackList(trackList);
+            Controller.popTrackWithIndex();
+            this.publishNewTrackList();
         }catch(e){
             console.log(e);
         }
     }
 
-    publishNewTrackList(newTrackList){
+    publishNewTrackList(): void {
+        const newTrackList = Controller.getTrackList();
+        console.log(newTrackList);
+
+        storeChannel.publish(StoreChannelType.TRACK_CHANNEL, newTrackList);
         storeChannel.publish(StoreChannelType.TRACK_LIST_CHANNEL, newTrackList);
         newTrackList.forEach((track) => {
             storeChannel.publish(StoreChannelType.TRACK_SECTION_LIST_CHANNEL, {

--- a/frontend/src/common/command/DeleteTrackCommand.ts
+++ b/frontend/src/common/command/DeleteTrackCommand.ts
@@ -5,16 +5,23 @@ import { storeChannel } from '@store';
 import { StoreChannelType } from '@types';
 
 class DeleteTrackCommand extends Command {
+    private trackId : number;
+    private removeIdx: number;
     private removedTrack: Track | undefined;
 
-    constructor(){
+    constructor(trackId: number){
         super();
+        this.trackId = trackId;
+        this.removeIdx = 0;
         this.removedTrack;
     }
 
     execute(){
         try{
-            this.removedTrack = Controller.popTrackWithIndex();
+            const trackList = Controller.getTrackList();
+            this.removeIdx = trackList.findIndex((track) => track.id === this.trackId);
+            this.removedTrack = Controller.removeTrackById(this.trackId);
+            
             this.publishNewTrackList();
         }catch(e){
             console.log(e);
@@ -25,7 +32,7 @@ class DeleteTrackCommand extends Command {
         try{
             if(!this.removedTrack) return;
 
-            Controller.pushTrackWidthIndex(this.removedTrack);
+            Controller.insertTrack(this.removeIdx, this.removedTrack);
             this.publishNewTrackList();
         }catch(e){
             console.log(e);

--- a/frontend/src/common/command/DeleteTrackCommand.ts
+++ b/frontend/src/common/command/DeleteTrackCommand.ts
@@ -1,0 +1,49 @@
+import { Command } from '@command';
+import { Controller } from '@controllers';
+import { Track } from '@model';
+import { storeChannel } from '@store';
+import { StoreChannelType } from '@types';
+
+class DeleteTrackCommand extends Command {
+    private removedTrack: Track | undefined;
+
+    constructor(){
+        super();
+        this.removedTrack;
+    }
+
+    execute(){
+        try{
+            this.removedTrack = Controller.popTrackWithIndex();
+            this.publishNewTrackList();
+        }catch(e){
+            console.log(e);
+        }
+    }
+
+    undo(){
+        try{
+            if(!this.removedTrack) return;
+
+            Controller.pushTrackWidthIndex(this.removedTrack);
+            this.publishNewTrackList();
+        }catch(e){
+            console.log(e);
+        }
+    }
+
+    publishNewTrackList(): void {
+        const newTrackList = Controller.getTrackList();
+        
+        storeChannel.publish(StoreChannelType.TRACK_CHANNEL, newTrackList);
+        storeChannel.publish(StoreChannelType.TRACK_LIST_CHANNEL, newTrackList);
+        newTrackList.forEach((track) => {
+            storeChannel.publish(StoreChannelType.TRACK_SECTION_LIST_CHANNEL, {
+                trackId: track.id,
+                trackSectionList: track.trackSectionList
+            });
+        });
+    }
+}
+
+export default DeleteTrackCommand;

--- a/frontend/src/common/command/DeleteTrackCommand.ts
+++ b/frontend/src/common/command/DeleteTrackCommand.ts
@@ -16,10 +16,9 @@ class DeleteTrackCommand extends Command {
         this.removedTrack;
     }
 
-    execute(){
+    execute(): void {
         try{
-            const trackList = Controller.getTrackList();
-            this.removeIdx = trackList.findIndex((track) => track.id === this.trackId);
+            this.removeIdx = this.calculateRemoveIdx();
             this.removedTrack = Controller.removeTrackById(this.trackId);
             
             this.publishNewTrackList();
@@ -28,11 +27,16 @@ class DeleteTrackCommand extends Command {
         }
     }
 
-    undo(){
+    calculateRemoveIdx(): number {
+        const trackList = Controller.getTrackList();
+        return trackList.findIndex((track) => track.id === this.trackId);
+    }
+
+    undo(): void {
         try{
             if(!this.removedTrack) return;
-
             Controller.insertTrack(this.removeIdx, this.removedTrack);
+
             this.publishNewTrackList();
         }catch(e){
             console.log(e);
@@ -41,7 +45,7 @@ class DeleteTrackCommand extends Command {
 
     publishNewTrackList(): void {
         const newTrackList = Controller.getTrackList();
-        
+
         storeChannel.publish(StoreChannelType.TRACK_CHANNEL, newTrackList);
         storeChannel.publish(StoreChannelType.TRACK_LIST_CHANNEL, newTrackList);
         newTrackList.forEach((track) => {

--- a/frontend/src/common/command/index.js
+++ b/frontend/src/common/command/index.js
@@ -5,3 +5,4 @@ export { default as PasteCommand } from './PasteCommand';
 export { default as SplitCommand } from './SplitCommand';
 export { default as MoveCommand } from './MoveCommand';
 export { default as AddTrackCommand} from './AddTrackCommand';
+export { default as DeleteTrackCommand} from './DeleteTrackCommand';

--- a/frontend/src/components/App/App.ts
+++ b/frontend/src/components/App/App.ts
@@ -51,7 +51,7 @@ import { Controller, CommandController } from "@controllers";
         Controller.setCursorMode(CursorType.SELECT_MODE);
       }
       else if (e.which === KeyBoard.DELETE && !isCtrl) {
-        CommandController.excuteDeleteCommand();
+        CommandController.executeDeleteCommand();
       }
       else if (e.which === KeyBoard.LEFT && !isCtrl) {
         Controller.audioFastRewind();
@@ -72,16 +72,16 @@ import { Controller, CommandController } from "@controllers";
         Controller.setClipBoard();
       }
       else if (e.which === KeyBoard.X && isCtrl) {
-        CommandController.excuteCutCommand();
+        CommandController.executeCutCommand();
       }
       else if (e.which === KeyBoard.V && isCtrl) {
-        CommandController.excutePasteCommand();
+        CommandController.executePasteCommand();
       }
       else if (e.which === KeyBoard.Z && isCtrl) {
-        CommandController.excuteUndoCommand();
+        CommandController.executeUndoCommand();
       }
       else if (e.which === KeyBoard.Y && isCtrl) {
-        CommandController.excuteRedoCommand();
+        CommandController.executeRedoCommand();
       }
     }
 

--- a/frontend/src/components/AudioTrack/AudioTrackMenu/AudioTrackMenu.ts
+++ b/frontend/src/components/AudioTrack/AudioTrackMenu/AudioTrackMenu.ts
@@ -63,7 +63,7 @@ import './AudioTrackMenu.scss';
 
     trackAddMenuClickListener(e): void {
       try{
-        CommandController.excuteAddTrackCommand();
+        CommandController.executeAddTrackCommand();
       }catch(e){
         console.log(e);
       }

--- a/frontend/src/components/AudioTrack/AudioTrackOption/AudioTrackOption.ts
+++ b/frontend/src/components/AudioTrack/AudioTrackOption/AudioTrackOption.ts
@@ -1,8 +1,6 @@
 import { EventKeyType, EventType, TrackOptionType } from '@types';
 import { EventUtil } from '@util';
-import { StoreChannelType } from '@types';
-import { storeChannel } from '@store';
-import { Controller } from '@controllers';
+import { Controller, CommandController } from '@controllers';
 import './AudioTrackOption.scss';
 
 (() => {
@@ -111,7 +109,7 @@ import './AudioTrackOption.scss';
     }
 
     deleteClickListener(): void {
-      console.log('delete');
+      CommandController.executeDeleteTrackCommand();
     }
   };
 

--- a/frontend/src/components/AudioTrack/AudioTrackOption/AudioTrackOption.ts
+++ b/frontend/src/components/AudioTrack/AudioTrackOption/AudioTrackOption.ts
@@ -109,7 +109,7 @@ import './AudioTrackOption.scss';
     }
 
     deleteClickListener(): void {
-      CommandController.executeDeleteTrackCommand();
+      CommandController.executeDeleteTrackCommand(this.trackId);
     }
   };
 

--- a/frontend/src/components/AudioTrack/AudioTrackSection/AudioTrackSection.ts
+++ b/frontend/src/components/AudioTrack/AudioTrackSection/AudioTrackSection.ts
@@ -241,7 +241,7 @@ import './AudioTrackSection.scss';
 
     cutModeClickHandler(e): void {
       const cursorPosition = e.pageX;
-      CommandController.excuteSplitCommand(cursorPosition, this.trackId, this.sectionId);
+      CommandController.executeSplitCommand(cursorPosition, this.trackId, this.sectionId);
     }
 
     trackSectionMouseMoveListener(e): void {

--- a/frontend/src/components/EditTools/EditTools.ts
+++ b/frontend/src/components/EditTools/EditTools.ts
@@ -175,23 +175,23 @@ import './EditTools.scss'
     }
 
     cutListener(e) {
-      CommandController.excuteCutCommand();
+      CommandController.executeCutCommand();
     }
 
     pasteListener(e) {
-      CommandController.excutePasteCommand();
+      CommandController.executePasteCommand();
     }
 
     deleteListener(): void {
-      CommandController.excuteDeleteCommand();
+      CommandController.executeDeleteCommand();
     }
 
     undoListener(): void {
-      CommandController.excuteUndoCommand();
+      CommandController.executeUndoCommand();
     }
 
     redoListener(): void {
-      CommandController.excuteRedoCommand();
+      CommandController.executeRedoCommand();
     }
 
     subscribe(): void {

--- a/frontend/src/components/Main/MainMiddleContent/MainTrackOptionListArea/MainTrackOptionListArea.ts
+++ b/frontend/src/components/Main/MainMiddleContent/MainTrackOptionListArea/MainTrackOptionListArea.ts
@@ -37,8 +37,6 @@ import './MainTrackOptionListArea.scss';
 
     trackListObserverCallback(newTrackList: Track[]): void {
         try{
-            console.log(newTrackList);
-            
             this.trackList = newTrackList;
             this.render();
         }catch(e){

--- a/frontend/src/controllers/CommandController.ts
+++ b/frontend/src/controllers/CommandController.ts
@@ -64,7 +64,10 @@ const executeAddTrackCommand = (): void => {
 }
 
 const executeDeleteTrackCommand = (trackId: number): void => {
-    if(isMinLengthOfTrackList()) return;
+    if(isMinLengthOfTrackList()) {
+        alert("트랙은 최소 3개 이상 존재해야합니다.");
+        return;
+    }
     
     const deleteTrackCommand = new DeleteTrackCommand(trackId);
     CommandManager.execute(deleteTrackCommand);

--- a/frontend/src/controllers/CommandController.ts
+++ b/frontend/src/controllers/CommandController.ts
@@ -1,19 +1,20 @@
 import { store } from '@store';
 import { CopyUtil} from '@util';
 import { Controller } from "@controllers";
-import { CommandManager, DeleteCommand, PasteCommand, SplitCommand, AddTrackCommand } from '@command';
+import { CommandManager, DeleteCommand, PasteCommand, SplitCommand, AddTrackCommand, DeleteTrackCommand } from '@command';
+import { check } from 'prettier';
 
-const excuteUndoCommand = () => {
+const executeUndoCommand = () => {
     if (CommandManager.undoList.length === 0) return;
     CommandManager.undo();
 };
   
-const excuteRedoCommand = () => {
+const executeRedoCommand = () => {
     if (CommandManager.redoList.length === 0) return;
     CommandManager.redo();
 };
 
-const excuteDeleteCommand = () => {
+const executeDeleteCommand = () => {
     const { focusList } = store.getState();
 
     if (focusList.length === 0) return;
@@ -21,14 +22,14 @@ const excuteDeleteCommand = () => {
     CommandManager.execute(command);
 };
 
-const excuteCutCommand = () => {
+const executeCutCommand = () => {
     if (!Controller.setClipBoard()) return;
   
     const command = new DeleteCommand();
     CommandManager.execute(command);
   };
   
-const excutePasteCommand = () => {
+const executePasteCommand = () => {
     const { focusList, trackList, clipBoard } = store.getState();
   
     if (focusList.length !== 1) return false;
@@ -48,7 +49,7 @@ const excutePasteCommand = () => {
     CommandManager.execute(command);
 };
 
-const excuteSplitCommand = (cursorPosition: number, trackId: number, sectionId: number): void => {
+const executeSplitCommand = (cursorPosition: number, trackId: number, sectionId: number): void => {
     const track = Controller.getTrack(trackId);
     const trackSection = track?.trackSectionList.find((section) => section.id === sectionId);
     if (!trackSection || !track) return;
@@ -57,17 +58,32 @@ const excuteSplitCommand = (cursorPosition: number, trackId: number, sectionId: 
     CommandManager.execute(splitCommand);
 };
 
-const excuteAddTrackCommand = (): void => {
+const executeAddTrackCommand = (): void => {
     const addTrackCommand = new AddTrackCommand();
     CommandManager.execute(addTrackCommand);
 }
 
+const executeDeleteTrackCommand = (): void => {
+    if(isMinLengthOfTrackList()) return;
+    
+    const deleteTrackCommand = new DeleteTrackCommand();
+    CommandManager.execute(deleteTrackCommand);
+};
+
+const isMinLengthOfTrackList = (): Boolean => {
+    const { trackList } = store.getState();
+    const minLength = 3;
+
+    return trackList.length === minLength;
+}
+
 export default {
-    excuteUndoCommand,
-    excuteRedoCommand,
-    excuteDeleteCommand,
-    excuteCutCommand,
-    excutePasteCommand,
-    excuteSplitCommand,
-    excuteAddTrackCommand
+    executeUndoCommand,
+    executeRedoCommand,
+    executeDeleteCommand,
+    executeCutCommand,
+    executePasteCommand,
+    executeSplitCommand,
+    executeAddTrackCommand,
+    executeDeleteTrackCommand
 }

--- a/frontend/src/controllers/CommandController.ts
+++ b/frontend/src/controllers/CommandController.ts
@@ -63,10 +63,10 @@ const executeAddTrackCommand = (): void => {
     CommandManager.execute(addTrackCommand);
 }
 
-const executeDeleteTrackCommand = (): void => {
+const executeDeleteTrackCommand = (trackId: number): void => {
     if(isMinLengthOfTrackList()) return;
     
-    const deleteTrackCommand = new DeleteTrackCommand();
+    const deleteTrackCommand = new DeleteTrackCommand(trackId);
     CommandManager.execute(deleteTrackCommand);
 };
 

--- a/frontend/src/controllers/controller.ts
+++ b/frontend/src/controllers/controller.ts
@@ -478,6 +478,36 @@ const popTrackWithIndex = (): Track | undefined => {
   return removedTrack;
 };
 
+const removeTrackById = (trackId: number): Track | undefined => {
+  const { trackList } = store.getState();
+  const trackToRemove = trackList.find((track) => track.id === trackId);
+
+  if(!trackToRemove) return;
+  const newTrackList = trackList.filter((track) => track.id !== trackId);
+  
+  store.setTrackList(newTrackList);
+  return trackToRemove;
+}
+
+const insertTrack = (removeIdx: number, track: Track): void => {
+  const { trackList } = store.getState();
+
+  let newTrackList: Track[] = [];
+  if(removeIdx === 0){
+    trackList.unshift(track);
+    newTrackList = trackList;
+  }else if(removeIdx === trackList.length - 1){
+    trackList.push(track);
+    newTrackList = trackList;
+  }else{
+    const leftTrackList = trackList.slice(0,removeIdx);
+    const rightTrackList = trackList.slice(removeIdx, trackList.length);
+    newTrackList = [...leftTrackList, track, ...rightTrackList];
+  }
+
+  store.setTrackList(newTrackList);
+}
+
 export default {
   getTrackSection,
   getSource,
@@ -542,5 +572,7 @@ export default {
   changeSectionDragStartData,
   getSectionDragStartData,
   popTrackWithIndex,
-  pushTrackWidthIndex
+  pushTrackWidthIndex,
+  removeTrackById,
+  insertTrack
 };

--- a/frontend/src/controllers/controller.ts
+++ b/frontend/src/controllers/controller.ts
@@ -489,21 +489,14 @@ const removeTrackById = (trackId: number): Track | undefined => {
   return trackToRemove;
 }
 
-const insertTrack = (removeIdx: number, track: Track): void => {
+const insertTrack = (insertIdx: number, trackToInsert: Track): void => {
   const { trackList } = store.getState();
-
-  let newTrackList: Track[] = [];
-  if(removeIdx === 0){
-    trackList.unshift(track);
-    newTrackList = trackList;
-  }else if(removeIdx === trackList.length - 1){
-    trackList.push(track);
-    newTrackList = trackList;
-  }else{
-    const leftTrackList = trackList.slice(0,removeIdx);
-    const rightTrackList = trackList.slice(removeIdx, trackList.length);
-    newTrackList = [...leftTrackList, track, ...rightTrackList];
-  }
+  
+  const newTrackList = Array(trackList.length + 1).fill(0).map(( _, idx) => {
+    if(idx < insertIdx) return trackList[idx];
+    if(idx > insertIdx) return trackList[idx - 1];
+    return trackToInsert;
+  });
 
   store.setTrackList(newTrackList);
 }

--- a/frontend/src/controllers/controller.ts
+++ b/frontend/src/controllers/controller.ts
@@ -461,12 +461,21 @@ const getSectionDragStartData = (): SectionDragStartData | null => {
   return sectionDragStartData;
 };
 
-const popTrackWithIndex = (): void => {
+const pushTrackWidthIndex = (newTrack: Track): void => {
   const { trackList, trackIndex } = store.getState();
-  trackList.pop();
+  const newTrackList = trackList.concat(newTrack);
+
+  store.setTrackList(newTrackList);
+  store.setTrackIndex(trackIndex + 1);
+}
+
+const popTrackWithIndex = (): Track | undefined => {
+  const { trackList, trackIndex } = store.getState();
+  const removedTrack = trackList.pop();
   
   store.setTrackList(trackList);
   store.setTrackIndex(trackIndex - 1);
+  return removedTrack;
 };
 
 export default {
@@ -532,5 +541,6 @@ export default {
   getCurrentScrollAmount,
   changeSectionDragStartData,
   getSectionDragStartData,
-  popTrackWithIndex
+  popTrackWithIndex,
+  pushTrackWidthIndex
 };

--- a/frontend/src/controllers/controller.ts
+++ b/frontend/src/controllers/controller.ts
@@ -461,6 +461,13 @@ const getSectionDragStartData = (): SectionDragStartData | null => {
   return sectionDragStartData;
 };
 
+const popTrackWithIndex = (): void => {
+  const { trackList, trackIndex } = store.getState();
+  trackList.pop();
+  
+  store.setTrackList(trackList);
+  store.setTrackIndex(trackIndex - 1);
+};
 
 export default {
   getTrackSection,
@@ -524,5 +531,6 @@ export default {
   getCurrentScrollTime,
   getCurrentScrollAmount,
   changeSectionDragStartData,
-  getSectionDragStartData
+  getSectionDragStartData,
+  popTrackWithIndex
 };

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -265,6 +265,14 @@ const store = new (class Store {
   setSectionDragStartData(newDragStartData: SectionDragStartData): void {
     this.state = { ...this.state, sectionDragStartData: newDragStartData };
   }
+
+  setTrackList(newTrackList: Track[]): void {
+    this.state = {...this.state, trackList: newTrackList};
+  }
+
+  setTrackIndex(newTrackIndex: number): void {
+    this.state =  {...this.state, trackIndex: newTrackIndex};
+  }
 })();
 
 export { store };


### PR DESCRIPTION
## 📕 제목

트랙 추가하기 커맨드 수정 및 트랙 삭제하기 커맨드 구현
관련이슈 #110 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 트랙 추가하기 커맨드 로직을 id를 고려한 로직으로 변경
  - 트랙을 추가하고, 다시 undo할 때 id가 계속 증가되지 않도록 undo 할 때 인덱스도 같이 반영할 수 있도록 수정했습니다 :-)
![ezgif com-gif-maker (20)](https://user-images.githubusercontent.com/32856129/101848753-a0476280-3b99-11eb-8d05-cd1c496e8c3e.gif)
- [x] 트랙 삭제하기 커맨드 정의
  - 트랙의 option을 통해 delete 버튼을 클릭하면 트랙 삭제하기 커맨드가 실행되도록 구현하였습니다
  - 트랙 삭제하기는 최소 3개의 트랙이 남은 경우, 더 이상 삭제하기 커맨드가 실행되지 않도록 하였습니다
  - 트랙 option의 delete 버튼을 클릭하면 해당 트랙이 삭제되고, undo시 해당 위치에 다시 돌아올 수 있도록 구현하였습니다 :-)
![ezgif com-gif-maker (21)](https://user-images.githubusercontent.com/32856129/101848859-de448680-3b99-11eb-95dc-a1744fd85941.gif)

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 트랙 추가하기시 전체 트랙 사이즈가 계속 증가하는 버그는 아직 해결하지 못했습니다
  - 하지만 버그의 이유는 알아냈습니다!!! 조만간 수정할게용 :-)
