### PR TITLE
전체 재생 시간 끝으로 마커가 이동 안되는 버그 수정

### DIFF
--- a/frontend/src/common/audio/AudioManager.ts
+++ b/frontend/src/common/audio/AudioManager.ts
@@ -750,11 +750,10 @@ class AudioManager {
       this.setMaxPlayTime();
 
       setTimeout(() => {
-        const maxTrackPlayTime = Controller.getMaxTrackPlayTime();
         this.setMaxPlayTime();
 
-        const widthPixel = ZoomController.getCurrentPixelPerSecond();
-        Controller.setMarkerWidth([widthPixel * this.maxPlayTime, 1]);
+        const widthPixel = ZoomController.getCurrentPixelPerSecond(); 
+        Controller.initMarkerWidth(widthPixel * this.maxPlayTime);
         Controller.changeMarkerPlayStringTime(this.maxPlayTime);
         Controller.changeMarkerNumberTime(this.maxPlayTime);
       }, TIMER_TIME + 1);


### PR DESCRIPTION
## 📕 제목

전체 재생 시간 끝으로 마커가 이동 안되는 버그 수정
관련이슈 #161

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 전체 재생 시간 끝으로 마커가 이동 안되는 버그 수정

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

