### PR TITLE
트랙, 재생바 반응형 사이즈 변경 적용 및 폴리필 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2606,6 +2606,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@webcomponents/webcomponentsjs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
+    "@webcomponents/webcomponentsjs": "^2.5.0",
     "lamejs": "^1.2.0",
     "typescript": "^4.0.5"
   },

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AUDI-AUDIO-EDITOR</title>
+    <script src="./node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+    <script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 </head>
 
 <body>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,8 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AUDI-AUDIO-EDITOR</title>
-    <script src="./node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 </head>
 
 <body>

--- a/frontend/src/components/Main/MainControllerContent/MainControllerContent.ts
+++ b/frontend/src/components/Main/MainControllerContent/MainControllerContent.ts
@@ -1,16 +1,20 @@
+import { Controller } from '@controllers';
 import './MainControllerContent.scss';
 import { StoreChannelType } from '@types'
 import { storeChannel } from '@store'
 
 (() => {
   const MainControllerContent = class extends HTMLElement {
+    private resizeTimer: NodeJS.Timeout | null;
 
     constructor() {
       super();
+      this.resizeTimer = null;
     }
 
     connectedCallback(): void {
       this.render();
+      this.initEvent();
       this.subscribe();
     }
 
@@ -22,6 +26,22 @@ import { storeChannel } from '@store'
           <audi-audio-meter></audi-audio-meter>
         </div>
         `;
+    }
+
+    initEvent(){
+      window.addEventListener('resize', this.windowResizeListener.bind(this));
+    }
+
+    windowResizeListener(e) {
+      if (this.resizeTimer) {
+        clearTimeout(this.resizeTimer);
+      }
+
+      this.resizeTimer = setTimeout(() => {
+        Controller.changeCurrentScrollAmount(0);
+        this.render();
+        this.initEvent();
+      }, 100);
     }
 
     subscribe(): void {

--- a/frontend/src/components/Main/MainTrackContent/AudioTrack/AudioTrackSection/AudioTrackSection.ts
+++ b/frontend/src/components/Main/MainTrackContent/AudioTrack/AudioTrackSection/AudioTrackSection.ts
@@ -12,7 +12,6 @@ import './AudioTrackSection.scss';
     private cursorMode: CursorType | undefined;
     private canvasWidth: number;
     private canvasHeight: number;
-    private maxTrackPlayTime: number;
     private maxTrackWidth: number;
     private currentScrollAmount: number;
     private trackCanvasElement: HTMLCanvasElement | undefined | null;
@@ -33,7 +32,6 @@ import './AudioTrackSection.scss';
       this.canvasWidth = 0;
       this.canvasHeight = 0;
       this.maxTrackWidth = 0;
-      this.maxTrackPlayTime = 0;
       this.currentScrollAmount = 0;
       this.trackCanvasElement;
       this.trackContainerElement = null;
@@ -86,7 +84,6 @@ import './AudioTrackSection.scss';
       this.cursorMode = Controller.getCursorMode();
       this.sectionData = Controller.getSectionData(this.trackId, this.sectionId);
       this.maxTrackWidth = Controller.getMaxTrackWidth();
-      this.maxTrackPlayTime = Controller.getMaxTrackPlayTime();
       this.currentScrollAmount = Controller.getCurrentScrollAmount();
       this.trackCanvasElement = this.querySelector<HTMLCanvasElement>('.audio-track-section');
       this.cutLineElement = document.getElementById(`section-cut-line-${this.trackId}`);
@@ -109,7 +106,6 @@ import './AudioTrackSection.scss';
       this.calculateCanvasSize(duration);
       this.resizeCanvas();
       this.drawCanvas(sectionChannelData, sectionColor);
-      // this.resizeTrackArea();
     }
 
     calculateCanvasSize(duration: number): void {
@@ -181,7 +177,6 @@ import './AudioTrackSection.scss';
         ],
         bindObj: this
       });
-      window.addEventListener('resize', this.windowResizeListener.bind(this));
     }
 
     trackSectiondragoverListener(e): void {
@@ -204,13 +199,11 @@ import './AudioTrackSection.scss';
     trackSectiondragStartListener(e): void {
       if (!this.trackContainerElement) return;
       const offsetLeft = this.trackContainerElement.getBoundingClientRect().left;
-
-      this.maxTrackPlayTime = Controller.getMaxTrackPlayTime();
       const currentScrollAmount = Controller.getCurrentScrollAmount();
 
       const prevCursorPosition = e.pageX + currentScrollAmount;
-
       const prevCursorTime = TimeUtil.calculateTimeOfCursorPosition(offsetLeft, prevCursorPosition);
+      
       const trackSection = Controller.getTrackSection(this.trackId, this.sectionId);
 
       if (!trackSection) return;
@@ -285,10 +278,6 @@ import './AudioTrackSection.scss';
       if (!this.cutLineElement) return;
       this.cutLineElement?.classList.remove('hide');
       this.cutLineElement.style.left = `${location}px`;
-    }
-
-    windowResizeListener(e) {
-      this.drawTrackSection();
     }
 
     subscribe(): void {

--- a/frontend/src/components/Main/MainTrackContent/MainTrackContent.ts
+++ b/frontend/src/components/Main/MainTrackContent/MainTrackContent.ts
@@ -1,5 +1,4 @@
 import './MainTrackContent.scss';
-import { Track } from '@model';
 import { Controller } from '@controllers';
 import { EventUtil, MarkerEventUtil, TimeUtil, WidthUtil } from '@util';
 import { EventType, EventKeyType, StoreChannelType } from '@types';
@@ -7,25 +6,21 @@ import { storeChannel } from "@store";
 
 (() => {
   const MainTrackContent = class extends HTMLElement {
-    private trackList: Track[];
     private mainAudioTrackContainerEventZone: HTMLElement | null;
     private defaultStartX: number;
     private markerElement: HTMLElement | null;
-    private mainWidth: number;
-    private maxTrackPlayTime: number;
     private currentScrollAmount: number;
     private mainTrackRightElement: HTMLElement | null;
+    private resizeTimer: NodeJS.Timeout | null;
 
     constructor() {
       super();
-      this.trackList = Controller.getTrackList();
       this.defaultStartX = 0;
       this.markerElement = null;
-      this.mainWidth = 0;
-      this.maxTrackPlayTime = Controller.getMaxTrackPlayTime();
       this.currentScrollAmount = Controller.getCurrentScrollAmount();
       this.mainAudioTrackContainerEventZone = null;
       this.mainTrackRightElement = null;
+      this.resizeTimer = null;
     }
 
     connectedCallback(): void {
@@ -78,8 +73,6 @@ import { storeChannel } from "@store";
       this.mainTrackRightElement = this.querySelector('.audi-main-track-right');
 
       if (!playbarElement || !this.mainAudioTrackContainerEventZone) return;
-
-      this.mainWidth = playbarElement?.getBoundingClientRect().right - playbarElement?.getBoundingClientRect().left;
       this.defaultStartX = this.mainAudioTrackContainerEventZone?.getBoundingClientRect().left;
       this.markerElement = document.querySelector('.marker');
     }
@@ -103,6 +96,8 @@ import { storeChannel } from "@store";
         ],
         bindObj: this.mainAudioTrackContainerEventZone
       });
+
+      window.addEventListener('resize', this.windowResizeListener.bind(this));
     }
 
     focusResetListener(e): void {
@@ -128,8 +123,21 @@ import { storeChannel } from "@store";
       Controller.changeCursorNumberTime(timeOfCursorPosition);
     };
 
+    windowResizeListener(e) {
+      if (this.resizeTimer) {
+        clearTimeout(this.resizeTimer);
+      }
+
+      this.resizeTimer = setTimeout(() => {
+        Controller.changeMaxTrackWidth(0);
+        this.render();
+        this.initElement();
+        this.initEvent();
+        this.renderPlaybarScrollArea();
+      }, 100);
+    }
+
     subscribe(): void {
-      storeChannel.subscribe(StoreChannelType.MAX_TRACK_PLAY_TIME_CHANNEL, this.maxTrackPlayTimeObserverCallback, this);
       storeChannel.subscribe(StoreChannelType.CURRENT_SCROLL_AMOUNT_CHANNEL, this.currentScrollAmountObserverCallback, this);
       storeChannel.subscribe(StoreChannelType.ZOOM_RATE_CHANNEL, this.zoomRateObserverCallback, this);
     }
@@ -139,18 +147,8 @@ import { storeChannel } from "@store";
     }
 
     unsubscribe(): void {
-      storeChannel.unsubscribe(StoreChannelType.MAX_TRACK_PLAY_TIME_CHANNEL, this.maxTrackPlayTimeObserverCallback, this);
       storeChannel.unsubscribe(StoreChannelType.CURRENT_SCROLL_AMOUNT_CHANNEL, this.currentScrollAmountObserverCallback, this);
       storeChannel.unsubscribe(StoreChannelType.ZOOM_RATE_CHANNEL, this.zoomRateObserverCallback, this);
-    }
-
-    maxTrackPlayTimeObserverCallback(maxTrackPlayTime: number): void {
-      try {
-        this.maxTrackPlayTime = maxTrackPlayTime;
-        this.initEvent();
-      } catch (e) {
-        console.log(e);
-      }
     }
 
     currentScrollAmountObserverCallback(newCurrentScrollAmount: number): void {

--- a/frontend/src/components/Main/MainTrackContent/MainTrackScrollArea/MainTrackScrollArea.ts
+++ b/frontend/src/components/Main/MainTrackContent/MainTrackScrollArea/MainTrackScrollArea.ts
@@ -43,6 +43,7 @@ import { Track } from '@model'
     initEvent() {
       if (!this.trackScrollAreaElement) return;
       this.trackScrollAreaElement.addEventListener('scroll', this.scrollAreaScrollListener.bind(this));
+
     }
 
     scrollAreaScrollListener(e) {

--- a/frontend/src/components/Main/MainTrackContent/PlayBar/PlayBar.ts
+++ b/frontend/src/components/Main/MainTrackContent/PlayBar/PlayBar.ts
@@ -19,6 +19,7 @@ import './PlayBar.scss';
     private playbarMarkerElementRight: HTMLElement | null;
     private playbarMarkerBlurZoneElement: HTMLElement | null;
     private playbarTimeElements: NodeListOf<HTMLDivElement> | null;
+    private playbarEventZoneElement: HTMLElement | null;
     private markerElement: HTMLElement | null;
     private trackScrollAreaElement: HTMLDivElement | null;
 
@@ -39,6 +40,7 @@ import './PlayBar.scss';
       this.playbarTimeElements = null;
       this.markerElement = null;
       this.trackScrollAreaElement = null;
+      this.playbarEventZoneElement = null;
 
       this.setPlayBarTimeInfo();
     }
@@ -64,6 +66,7 @@ import './PlayBar.scss';
     init(): void {
       this.render();
       this.initProperty();
+      this.resizePlayBarContainer();
       this.spreadPlayTimes();
       this.initPlayBarMarkerLocation();
       this.initEvent();
@@ -108,6 +111,8 @@ import './PlayBar.scss';
       this.playbarTimeElements = this.querySelectorAll('.playbar-time-container');
       this.markerElement = document.querySelector('.marker');
       this.trackScrollAreaElement = document.querySelector('.audi-main-audio-track-scroll-area');
+      this.playbarEventZoneElement = this.querySelector('.playbar-event-zone');
+      this.maxTrackWidth = Controller.getMaxTrackWidth();
 
       if (this.playBarContainerElement) {
         this.playBarLeftX = this.playBarContainerElement.getBoundingClientRect().left;
@@ -116,7 +121,7 @@ import './PlayBar.scss';
     }
 
     spreadPlayTimes() {
-      if (!this.playbarTimeElements || !this.playBarTimeDatas || !this.trackScrollAreaElement) return;
+      if (!this.playbarTimeElements || !this.playBarTimeDatas ) return;
 
       const pixelPerSecond = ZoomController.getCurrentPixelPerSecond();
       const playTimeInterval = ZoomController.getCurrentPlayTimeInterval();
@@ -153,7 +158,6 @@ import './PlayBar.scss';
       });
 
       this.addEventListener('dragstart', this.dragStartPlayBarMarkerListener.bind(this));
-      window.addEventListener('resize', this.windowResizeListener.bind(this));
     }
 
     mousemoveMarkerListener(e): void {
@@ -247,17 +251,6 @@ import './PlayBar.scss';
       return false;
     }
 
-    windowResizeListener(e) {
-      // const zoombarControllerElement = document.querySelector<HTMLDivElement>('.audi-zoombar-cotroller');
-      // if (!this.playBarContainerElement || !this.trackScrollAreaElement || !zoombarControllerElement) return;
-      // this.playBarLeftX = this.playBarContainerElement.getBoundingClientRect().left;
-      // this.playBarWidth = this.playBarContainerElement.getBoundingClientRect().right - this.playBarLeftX;
-      // this.trackScrollAreaElement.scrollLeft = initScrollAmount;
-      // zoombarControllerElement.style.left = `${initScrollAmount}`;
-      // this.currentScrollAmount = initScrollAmount;
-      // this.initEvent();
-    }
-
     subscribe(): void {
       storeChannel.subscribe(StoreChannelType.MAX_TRACK_WIDTH_CHANNEL, this.maxTrackWidthObserverCallback, this);
       storeChannel.subscribe(StoreChannelType.MAX_TRACK_PLAY_TIME_CHANNEL, this.maxTrackPlayTimeObserverCallback, this);
@@ -276,11 +269,12 @@ import './PlayBar.scss';
 
     maxTrackWidthObserverCallback(maxTrackWidth: number): void {
       this.maxTrackWidth = maxTrackWidth;
+      this.initProperty();
       this.resizePlayBarContainer();
       this.spreadPlayTimes();
     }
 
-    maxTrackPlayTimeObserverCallback(maxTrackPlayTime: number): void {
+    maxTrackPlayTimeObserverCallback(maxTrackPlayTime: number): void {    
       this.maxTrackPlayTime = maxTrackPlayTime;
 
       this.setPlayBarTimeInfo();
@@ -293,12 +287,14 @@ import './PlayBar.scss';
     }
 
     resizePlayBarContainer() {
-      if (!this.playBarContainerElement || !this.trackScrollAreaElement) return;
+      if (!this.playBarContainerElement || !this.trackScrollAreaElement || !this.playbarEventZoneElement || this.maxTrackWidth === 0) return;
 
       const scrollAreaWidth = this.trackScrollAreaElement.getBoundingClientRect().right - this.trackScrollAreaElement.getBoundingClientRect().left;
       const ratio = this.maxTrackWidth / scrollAreaWidth;
-
+      
       this.playBarContainerElement.style.width = `${100 * ratio}%`;
+      this.playbarEventZoneElement.style.width = `${100 * ratio}%`;
+
       this.playBarLeftX = this.playBarContainerElement.getBoundingClientRect().left;
       this.playBarWidth = this.playBarContainerElement.getBoundingClientRect().right - this.playBarLeftX;
     }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,2 +1,5 @@
 import '@components';
 import '@style';
+import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter';
+import '@webcomponents/webcomponentsjs/webcomponents-loader';
+ 


### PR DESCRIPTION
## 📕 제목

PR 제목
관련이슈 #138 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 재생바 사이즈가 늘어나지 않은 버그 수정
![ezgif com-gif-maker (17)](https://user-images.githubusercontent.com/32856129/102691863-f3cd4680-4252-11eb-8cf9-052fc89b0774.gif)
  - 재생바의 이벤트 존이 같이 늘어나지 않은 버그가 존재해서 같이 늘어가게끔 수정하였습니다
- [x] 반응형 사이즈 변경 적용
![ezgif com-gif-maker (18)](https://user-images.githubusercontent.com/32856129/102691894-1fe8c780-4253-11eb-81d1-8425c2d87e8c.gif)
  - 브라우저의 사이즈 변경에 따라 0.1초 기준으로  디바운싱을 적용하여 리렌더링을 하도록 수정하였습니다
- [x] 웹 컴포넌트 폴리필을 추가했습니다
  - IE와 Safari에도 정상적으로 동작할 수 있도록 폴리필을 추가했습니다
  - IE를 테스트 해봤는데, IE는 웹 컴포넌트 보다도 Web Audio API가 지원이 되지 않습니다.....
  - Safari는 테스트해보지 못했습니다! MAC 환경이 있는 분들 테스트 해주세요!!

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 디바운싱을 따로 유틸로 빼도 좋을 것 같네요 :-)
- 현재는 브라우저 리사이징에 따라 TrackContent와 ControllerContent를 리렌더링하고 있는데, 나중에 시간이 남는다면 최적화를 위해 렌더링을 최소화 해주는 것도 좋아보입니다 :-)
- 폴리필은 IE와 Safari에서 동작을 확인해보기 추가했는데, IE는 WebComponent 보다도 Web Audio API가 지원이 되지 않습니다.... Safari는 확인할 수가 없네요!! 정작 확인을 못했습니다! 혹시 Mac환경이 있다면 확인해주세요!
  - 추가한 폴리필 참고자료 : https://github.com/webcomponents/polyfills
