### PR TITLE
구간이동 시작시간이 음수가 나오느 버그 해결 및 AudioMeter max-width 추가

### DIFF
--- a/frontend/src/common/audio/AudioManager.ts
+++ b/frontend/src/common/audio/AudioManager.ts
@@ -266,8 +266,8 @@ class AudioManager {
 
   createAndConnectAnalyser(): void {
     this.analyser = this.audioContext.createAnalyser();
-    this.analyser.smoothingTimeConstant = 0.3;
-    this.analyser.fftSize = 512;
+    this.analyser.smoothingTimeConstant = 0.6;
+    this.analyser.fftSize = 1024;
     this.sourceInfo.forEach((source) => {
       try {
         if (!this.analyser) return;

--- a/frontend/src/common/util/DragUtil.ts
+++ b/frontend/src/common/util/DragUtil.ts
@@ -89,13 +89,15 @@ const getRenewTrackTimes = (currentTrack: Track, dragedTrackSection: TrackSectio
   if (newTrackStartTime < 0) {
     newTrackStartTime = 0;
   }
+
   let newTrackEndTime = newTrackStartTime + dragedTrackSection.length;
   let resultValid = ValidUtil.checkEnterTrack(dragedTrackSection, currentTrack.trackSectionList, newTrackStartTime, newTrackEndTime);
+
   if (resultValid.leftValid && !resultValid.rightValid) {
     const prevSection = getPrevTrackSection(currentTrack.id, dragedTrackSection.id, newTrackStartTime);
     if (prevSection) {
       const prevEndTime = prevSection.trackStartTime + prevSection.length
-      if (newTrackStartTime - prevEndTime < prevSection.length / 3) {
+      if (prevEndTime - newTrackStartTime < prevSection.length / 3) {
         newTrackStartTime = prevEndTime;
         newTrackEndTime = newTrackStartTime + dragedTrackSection.length;
       }
@@ -104,7 +106,7 @@ const getRenewTrackTimes = (currentTrack: Track, dragedTrackSection: TrackSectio
     const nextSection = getNextTrackSection(currentTrack.id, dragedTrackSection.id, newTrackStartTime, newTrackEndTime);
     if (nextSection) {
       const nextStartTime = nextSection.trackStartTime;
-      if (newTrackEndTime - nextStartTime < nextSection.length / 3) {
+      if (newTrackEndTime - nextStartTime < nextSection.length / 3 && nextStartTime - dragedTrackSection.length >= 0) {
         newTrackEndTime = nextStartTime;
         newTrackStartTime = newTrackEndTime - dragedTrackSection.length;
       }

--- a/frontend/src/components/Main/MainControllerContent/AudioMeter/AudioMeter.scss
+++ b/frontend/src/components/Main/MainControllerContent/AudioMeter/AudioMeter.scss
@@ -21,6 +21,7 @@
     height: 100%;
     border-radius: 2px;
     width: 0px;
+    max-width: 100%;
     box-shadow: 0 0 3px rgba(0,0,0,.25),
         inset 1px 1px 1px rgba(255,255,255,.75),
         inset -1px -1px 1px rgba(0,0,0,.4);


### PR DESCRIPTION
## 📕 제목

PR 제목
구간이동 시작시간이 음수가 나오느 버그 해결 및 AudioMeter max-width 추가
## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 트랙 시작부분과 TrackSection 사이에 공백이 있을 경우에 다른 트랙을 그 사이에 이동시키면 TrackStartTime이 음수로 이동되는 버그 해결
- [x] AudioMeter의 부드러운 반응을 위한 설정값 변경 및 max-width 100% 스타일 적용

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

